### PR TITLE
Update imports for FFTW removal from Base

### DIFF
--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -13,8 +13,12 @@ import AbstractFFTs: Plan, ScaledPlan,
                      rfft_output_size, brfft_output_size,
                      plan_inv, normalization
 
-if !isdefined(Base, :FFTW)
-    export dct, idct, dct!, idct!, plan_dct, plan_idct, plan_dct!, plan_idct!
+if VERSION >= v"0.7.0-DEV.602"
+    if isdefined(Base, :FFTW)
+        import Base.FFTW: dct, idct, dct!, idct!, plan_dct, plan_idct, plan_dct!, plan_idct!
+    else
+        export dct, idct, dct!, idct!, plan_dct, plan_idct, plan_dct!, plan_idct!
+    end
 end
 
 const depsfile = joinpath(dirname(@__DIR__), "deps", "deps.jl")


### PR DESCRIPTION
At first I was going to use this as a dummy PR to test the nightly binary which now does not include FFTW, but then I realized we should probably do this anyway.