### PR TITLE
Correct the RPM package name on Windows

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -25,7 +25,7 @@ provides(BSDPkg, "fftw3", [libfftw, libfftwf], os=:FreeBSD)
 
 if is_windows()
     using WinRPM
-    provides(WinRPM.RPM, "fftw3", [libfftw, libfftwf], os=:Windows)
+    provides(WinRPM.RPM, "libfftw3-3", [libfftw, libfftwf], os=:Windows)
 elseif is_apple()
     using Homebrew
     provides(Homebrew.HB, "fftw", [libfftw, libfftwf], os=:Darwin)


### PR DESCRIPTION
Given
```
julia> WinRPM.search("fft")
WinRPM Package Set:
  1. fftw3-debug (mingw64) - Debug information for package mingw64-fftw3
  2. fftw3-debugsource (mingw64) - Debug sources for package mingw64-fftw3
  3. fftw3-devel (mingw64) - Include Files and Libraries mandatory for Development
  4. libfftw3-3 (mingw64) - Discrete Fourier Transform (DFT) C Subroutine Library
```
it seems that WinRPM might be expecting the package to be called `libfftw3-3`. So let's try that on AppVeyor and see what happens.