### PR TITLE
Grabbag of fixes for 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
-julia 0.7.0-DEV.602
-AbstractFFTs 0.2.0
+julia 0.7.0-DEV.3449
+AbstractFFTs 0.3.0
 Reexport
-Compat 0.27.0
+Compat 0.60.0
 BinDeps 0.6.0

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,3 +1,5 @@
+using Libdl
+
 # If BLAS was compiled with MKL and the user wants MKL-based FFTs, we'll oblige.
 # In that case, we have to do this little dance to get around having to use BinDeps
 # for a library that's already linked to Julia.
@@ -18,6 +20,7 @@ if provider == "MKL" && Base.BLAS.vendor() === :mkl
     open(depsfile, "w") do f
         println(f, """
             # This is an auto-generated file, do not edit
+            using Libdl
             if Libdl.dlopen_e("$mklpath") == C_NULL
                 error("Unable to load MKL from '$mklpath'.\\n",
                       "Please rerun Pkg.build(\\"FFTW\\") and restart Julia.")

--- a/deps/build_fftw.jl
+++ b/deps/build_fftw.jl
@@ -1,10 +1,11 @@
+using Libdl
 using BinDeps
 using BinDeps: builddir, depsdir, libdir
 
 # Binaries is not a recognized provider on Linux >:/
 modified_defaults = false
 if !in(BinDeps.Binaries, BinDeps.defaults)
-    unshift!(BinDeps.defaults, BinDeps.Binaries)
+    pushfirst!(BinDeps.defaults, BinDeps.Binaries)
     modified_defaults = true
 end
 
@@ -23,7 +24,7 @@ end
 # Why can't everyone just agree on what to call this library...
 function makealiases(lib)
     major = string(FFTW_VER.major)
-    nover = replace(lib, major, "")
+    nover = replace(lib, major => "")
     return String[
         nover,
         join([lib, Libdl.dlext, major], "."),
@@ -116,5 +117,5 @@ else
 end
 
 if modified_defaults
-    shift!(BinDeps.defaults)
+    popfirst!(BinDeps.defaults)
 end

--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -3,6 +3,7 @@ __precompile__()
 module FFTW
 
 using Compat
+using LinearAlgebra
 using Reexport
 @reexport using AbstractFFTs
 
@@ -14,11 +15,7 @@ import AbstractFFTs: Plan, ScaledPlan,
                      rfft_output_size, brfft_output_size,
                      plan_inv, normalization
 
-if VERSION < v"0.7.0-DEV.986"
-    import Base.FFTW: dct, idct, dct!, idct!, plan_dct, plan_idct, plan_dct!, plan_idct!
-else
-    export dct, idct, dct!, idct!, plan_dct, plan_idct, plan_dct!, plan_idct!
-end
+export dct, idct, dct!, idct!, plan_dct, plan_idct, plan_dct!, plan_idct!
 
 const depsfile = joinpath(dirname(@__DIR__), "deps", "deps.jl")
 if isfile(depsfile)
@@ -29,12 +26,12 @@ else
 end
 
 # MKL provides its own FFTW
-fftw_vendor() = Base.BLAS.vendor() === :mkl ? :mkl : :fftw
+fftw_vendor() = BLAS.vendor() === :mkl ? :mkl : :fftw
 
 if fftw_vendor() === :mkl
     const libfftw_name = "libmkl_rt"
     const libfftwf_name = "libmkl_rt"
-elseif Compat.Sys.iswindows()
+elseif Sys.iswindows()
     const libfftw_name = "libfftw3"
     const libfftwf_name = "libfftw3f"
 else

--- a/src/dct.jl
+++ b/src/dct.jl
@@ -134,8 +134,7 @@ const sqrthalf = sqrt(0.5)
 const sqrt2 = sqrt(2.0)
 const onerange = 1:1
 
-function A_mul_B!(y::StridedArray{T}, p::DCTPlan{T,REDFT10},
-                  x::StridedArray{T}) where T
+function mul!(y::StridedArray{T}, p::DCTPlan{T,REDFT10}, x::StridedArray{T}) where T
     assert_applicable(p.plan, x, y)
     unsafe_execute!(p.plan, x, y)
     scale!(y, p.nrm)
@@ -150,8 +149,7 @@ function A_mul_B!(y::StridedArray{T}, p::DCTPlan{T,REDFT10},
 end
 
 # note: idct changes input data
-function A_mul_B!(y::StridedArray{T}, p::DCTPlan{T,REDFT01},
-                  x::StridedArray{T}) where T
+function mul!(y::StridedArray{T}, p::DCTPlan{T,REDFT01}, x::StridedArray{T}) where T
     assert_applicable(p.plan, x, y)
     scale!(x, p.nrm)
     r = p.r
@@ -166,9 +164,9 @@ function A_mul_B!(y::StridedArray{T}, p::DCTPlan{T,REDFT01},
 end
 
 *(p::DCTPlan{T,REDFT10,false}, x::StridedArray{T}) where {T} =
-    A_mul_B!(Array{T}(p.plan.osz), p, x)
+    mul!(Array{T}(undef, p.plan.osz), p, x)
 
 *(p::DCTPlan{T,REDFT01,false}, x::StridedArray{T}) where {T} =
-    A_mul_B!(Array{T}(p.plan.osz), p, copy(x)) # need copy to preserve input
+    mul!(Array{T}(undef, p.plan.osz), p, copy(x)) # need copy to preserve input
 
-*(p::DCTPlan{T,K,true}, x::StridedArray{T}) where {T,K} = A_mul_B!(x, p, x)
+*(p::DCTPlan{T,K,true}, x::StridedArray{T}) where {T,K} = mul!(x, p, x)

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -1,6 +1,7 @@
 # This file was formerly a part of Julia. License is MIT: https://julialang.org/license
 
-import Base: show, *, convert, unsafe_convert, size, strides, ndims, pointer, A_mul_B!
+import Base: show, *, convert, unsafe_convert, size, strides, ndims, pointer
+import LinearAlgebra: mul!
 
 """
     r2r(A, kind [, dims])
@@ -99,13 +100,13 @@ end
 
 # FFTW floating-point types:
 
-const fftwNumber = Union{Float64,Float32,Complex128,Complex64}
+const fftwNumber = Union{Float64,Float32,Complex{Float64},Complex{Float32}}
 const fftwReal = Union{Float64,Float32}
-const fftwComplex = Union{Complex128,Complex64}
-const fftwDouble = Union{Float64,Complex128}
-const fftwSingle = Union{Float32,Complex64}
-const fftwTypeDouble = Union{Type{Float64},Type{Complex128}}
-const fftwTypeSingle = Union{Type{Float32},Type{Complex64}}
+const fftwComplex = Union{Complex{Float64},Complex{Float32}}
+const fftwDouble = Union{Float64,Complex{Float64}}
+const fftwSingle = Union{Float32,Complex{Float32}}
+const fftwTypeDouble = Union{Type{Float64},Type{Complex{Float64}}}
+const fftwTypeSingle = Union{Type{Float32},Type{Complex{Float32}}}
 
 # For ESTIMATE plans, FFTW allows one to pass NULL for the array pointer,
 # since it is not written to.  Hence, it is convenient to create an
@@ -138,22 +139,22 @@ alignment_of(A::FakeArray) = Int32(0)
 # FFTW's api/import-wisdom-from-file.c file].
 
 function export_wisdom(fname::AbstractString)
-    f = ccall(:fopen, Ptr{Void}, (Cstring,Cstring), fname, :w)
+    f = ccall(:fopen, Ptr{Cvoid}, (Cstring,Cstring), fname, :w)
     systemerror("could not open wisdom file $fname for writing", f == C_NULL)
-    ccall((:fftw_export_wisdom_to_file,libfftw), Void, (Ptr{Void},), f)
-    ccall(:fputs, Int32, (Ptr{UInt8},Ptr{Void}), " "^256, f) # no NUL, hence no Cstring
-    ccall((:fftwf_export_wisdom_to_file,libfftwf), Void, (Ptr{Void},), f)
-    ccall(:fclose, Void, (Ptr{Void},), f)
+    ccall((:fftw_export_wisdom_to_file,libfftw), Cvoid, (Ptr{Cvoid},), f)
+    ccall(:fputs, Int32, (Ptr{UInt8},Ptr{Cvoid}), " "^256, f) # no NUL, hence no Cstring
+    ccall((:fftwf_export_wisdom_to_file,libfftwf), Cvoid, (Ptr{Cvoid},), f)
+    ccall(:fclose, Cvoid, (Ptr{Cvoid},), f)
 end
 
 function import_wisdom(fname::AbstractString)
-    f = ccall(:fopen, Ptr{Void}, (Cstring,Cstring), fname, :r)
+    f = ccall(:fopen, Ptr{Cvoid}, (Cstring,Cstring), fname, :r)
     systemerror("could not open wisdom file $fname for reading", f == C_NULL)
-    if ccall((:fftw_import_wisdom_from_file,libfftw),Int32,(Ptr{Void},),f)==0||
-       ccall((:fftwf_import_wisdom_from_file,libfftwf),Int32,(Ptr{Void},),f)==0
+    if ccall((:fftw_import_wisdom_from_file,libfftw),Int32,(Ptr{Cvoid},),f)==0||
+       ccall((:fftwf_import_wisdom_from_file,libfftwf),Int32,(Ptr{Cvoid},),f)==0
         error("failed to import wisdom from $fname")
     end
-    ccall(:fclose, Void, (Ptr{Void},), f)
+    ccall(:fclose, Cvoid, (Ptr{Cvoid},), f)
 end
 
 function import_system_wisdom()
@@ -164,15 +165,15 @@ function import_system_wisdom()
 end
 
 function forget_wisdom()
-    ccall((:fftw_forget_wisdom,libfftw), Void, ())
-    ccall((:fftwf_forget_wisdom,libfftwf), Void, ())
+    ccall((:fftw_forget_wisdom,libfftw), Cvoid, ())
+    ccall((:fftwf_forget_wisdom,libfftwf), Cvoid, ())
 end
 
 # Threads
 
 function set_num_threads(nthreads::Integer)
-    ccall((:fftw_plan_with_nthreads,libfftw), Void, (Int32,), nthreads)
-    ccall((:fftwf_plan_with_nthreads,libfftwf), Void, (Int32,), nthreads)
+    ccall((:fftw_plan_with_nthreads,libfftw), Cvoid, (Int32,), nthreads)
+    ccall((:fftwf_plan_with_nthreads,libfftwf), Cvoid, (Int32,), nthreads)
 end
 
 # pointer type for fftw_plan (opaque pointer)
@@ -185,11 +186,11 @@ const PlanPtr = Ptr{fftw_plan_struct}
 const NO_TIMELIMIT = -1.0 # from fftw3.h
 
 function set_timelimit(precision::fftwTypeDouble,seconds)
-    ccall((:fftw_set_timelimit,libfftw), Void, (Float64,), seconds)
+    ccall((:fftw_set_timelimit,libfftw), Cvoid, (Float64,), seconds)
 end
 
 function set_timelimit(precision::fftwTypeSingle,seconds)
-    ccall((:fftwf_set_timelimit,libfftwf), Void, (Float64,), seconds)
+    ccall((:fftwf_set_timelimit,libfftwf), Cvoid, (Float64,), seconds)
 end
 
 # Array alignment mod 16:
@@ -252,10 +253,10 @@ size(p::FFTWPlan) = p.sz
 unsafe_convert(::Type{PlanPtr}, p::FFTWPlan) = p.plan
 
 destroy_plan(plan::FFTWPlan{<:fftwDouble}) =
-    ccall((:fftw_destroy_plan,libfftw), Void, (PlanPtr,), plan)
+    ccall((:fftw_destroy_plan,libfftw), Cvoid, (PlanPtr,), plan)
 
 destroy_plan(plan::FFTWPlan{<:fftwSingle}) =
-    ccall((:fftwf_destroy_plan,libfftwf), Void, (PlanPtr,), plan)
+    ccall((:fftwf_destroy_plan,libfftwf), Cvoid, (PlanPtr,), plan)
 
 cost(plan::FFTWPlan{<:fftwDouble}) =
     ccall((:fftw_cost,libfftw), Float64, (PlanPtr,), plan)
@@ -266,7 +267,7 @@ function arithmetic_ops(plan::FFTWPlan{<:fftwDouble})
     # Change to individual Ref after we can allocate them on stack
     ref = Ref{NTuple{3,Float64}}()
     ptr = Ptr{Float64}(Base.unsafe_convert(Ptr{NTuple{3,Float64}}, ref))
-    ccall((:fftw_flops,libfftw), Void,
+    ccall((:fftw_flops,libfftw), Cvoid,
           (PlanPtr,Ptr{Float64},Ptr{Float64},Ptr{Float64}),
           plan, ptr, ptr + 8, ptr + 16)
     (round(Int64, ref[][1]), round(Int64, ref[][2]), round(Int64, ref[][3]))
@@ -275,7 +276,7 @@ function arithmetic_ops(plan::FFTWPlan{<:fftwSingle})
     # Change to individual Ref after we can allocate them on stack
     ref = Ref{NTuple{3,Float64}}()
     ptr = Ptr{Float64}(Base.unsafe_convert(Ptr{NTuple{3,Float64}}, ref))
-    ccall((:fftwf_flops,libfftwf), Void,
+    ccall((:fftwf_flops,libfftwf), Cvoid,
           (PlanPtr,Ptr{Float64},Ptr{Float64},Ptr{Float64}),
           plan, ptr, ptr + 8, ptr + 16)
     (round(Int64, ref[][1]), round(Int64, ref[][2]), round(Int64, ref[][3]))
@@ -380,49 +381,49 @@ colmajorstrides(sz) = isempty(sz) ? () : (1,cumprod(Int[sz[1:end-1]...])...)
 # Execute
 
 unsafe_execute!(plan::FFTWPlan{<:fftwDouble}) =
-    ccall((:fftw_execute,libfftw), Void, (PlanPtr,), plan)
+    ccall((:fftw_execute,libfftw), Cvoid, (PlanPtr,), plan)
 
 unsafe_execute!(plan::FFTWPlan{<:fftwSingle}) =
-    ccall((:fftwf_execute,libfftwf), Void, (PlanPtr,), plan)
+    ccall((:fftwf_execute,libfftwf), Cvoid, (PlanPtr,), plan)
 
 unsafe_execute!(plan::cFFTWPlan{T},
                 X::StridedArray{T}, Y::StridedArray{T}) where {T<:fftwDouble} =
-    ccall((:fftw_execute_dft,libfftw), Void,
+    ccall((:fftw_execute_dft,libfftw), Cvoid,
           (PlanPtr,Ptr{T},Ptr{T}), plan, X, Y)
 
 unsafe_execute!(plan::cFFTWPlan{T},
                 X::StridedArray{T}, Y::StridedArray{T}) where {T<:fftwSingle} =
-    ccall((:fftwf_execute_dft,libfftwf), Void,
+    ccall((:fftwf_execute_dft,libfftwf), Cvoid,
           (PlanPtr,Ptr{T},Ptr{T}), plan, X, Y)
 
 unsafe_execute!(plan::rFFTWPlan{Float64,FORWARD},
-                X::StridedArray{Float64}, Y::StridedArray{Complex128}) =
-    ccall((:fftw_execute_dft_r2c,libfftw), Void,
-          (PlanPtr,Ptr{Float64},Ptr{Complex128}), plan, X, Y)
+                X::StridedArray{Float64}, Y::StridedArray{Complex{Float64}}) =
+    ccall((:fftw_execute_dft_r2c,libfftw), Cvoid,
+          (PlanPtr,Ptr{Float64},Ptr{Complex{Float64}}), plan, X, Y)
 
 unsafe_execute!(plan::rFFTWPlan{Float32,FORWARD},
-                X::StridedArray{Float32}, Y::StridedArray{Complex64}) =
-    ccall((:fftwf_execute_dft_r2c,libfftwf), Void,
-          (PlanPtr,Ptr{Float32},Ptr{Complex64}), plan, X, Y)
+                X::StridedArray{Float32}, Y::StridedArray{Complex{Float32}}) =
+    ccall((:fftwf_execute_dft_r2c,libfftwf), Cvoid,
+          (PlanPtr,Ptr{Float32},Ptr{Complex{Float32}}), plan, X, Y)
 
-unsafe_execute!(plan::rFFTWPlan{Complex128,BACKWARD},
-                X::StridedArray{Complex128}, Y::StridedArray{Float64}) =
-    ccall((:fftw_execute_dft_c2r,libfftw), Void,
-          (PlanPtr,Ptr{Complex128},Ptr{Float64}), plan, X, Y)
+unsafe_execute!(plan::rFFTWPlan{Complex{Float64},BACKWARD},
+                X::StridedArray{Complex{Float64}}, Y::StridedArray{Float64}) =
+    ccall((:fftw_execute_dft_c2r,libfftw), Cvoid,
+          (PlanPtr,Ptr{Complex{Float64}},Ptr{Float64}), plan, X, Y)
 
-unsafe_execute!(plan::rFFTWPlan{Complex64,BACKWARD},
-                X::StridedArray{Complex64}, Y::StridedArray{Float32}) =
-    ccall((:fftwf_execute_dft_c2r,libfftwf), Void,
-          (PlanPtr,Ptr{Complex64},Ptr{Float32}), plan, X, Y)
+unsafe_execute!(plan::rFFTWPlan{Complex{Float32},BACKWARD},
+                X::StridedArray{Complex{Float32}}, Y::StridedArray{Float32}) =
+    ccall((:fftwf_execute_dft_c2r,libfftwf), Cvoid,
+          (PlanPtr,Ptr{Complex{Float32}},Ptr{Float32}), plan, X, Y)
 
 unsafe_execute!(plan::r2rFFTWPlan{T},
                 X::StridedArray{T}, Y::StridedArray{T}) where {T<:fftwDouble} =
-    ccall((:fftw_execute_r2r,libfftw), Void,
+    ccall((:fftw_execute_r2r,libfftw), Cvoid,
           (PlanPtr,Ptr{T},Ptr{T}), plan, X, Y)
 
 unsafe_execute!(plan::r2rFFTWPlan{T},
                 X::StridedArray{T}, Y::StridedArray{T}) where {T<:fftwSingle} =
-    ccall((:fftwf_execute_r2r,libfftwf), Void,
+    ccall((:fftwf_execute_r2r,libfftwf), Cvoid,
           (PlanPtr,Ptr{T},Ptr{T}), plan, X, Y)
 
 # NOTE ON GC (garbage collection):
@@ -444,11 +445,11 @@ function dims_howmany(X::StridedArray, Y::StridedArray,
     end
     ist = [strides(X)...]
     ost = [strides(Y)...]
-    dims = adjoint([sz[reg] ist[reg] ost[reg]])
+    dims = Matrix(transpose([sz[reg] ist[reg] ost[reg]]))
     oreg = [1:ndims(X);]
     oreg[reg] = 0
     oreg = filter(d -> d > 0, oreg)
-    howmany = adjoint([sz[oreg] ist[oreg] ost[oreg]])
+    howmany = Matrix(transpose([sz[oreg] ist[oreg] ost[oreg]]))
     return (dims, howmany)
 end
 
@@ -479,8 +480,8 @@ end
 
 # low-level FFTWPlan creation (for internal use in FFTW module)
 
-for (Tr,Tc,fftw,lib) in ((:Float64,:Complex128,"fftw",libfftw),
-                         (:Float32,:Complex64,"fftwf",libfftwf))
+for (Tr,Tc,fftw,lib) in ((:Float64,:(Complex{Float64}),"fftw",libfftw),
+                         (:Float32,:(Complex{Float32}),"fftwf",libfftwf))
     @eval function cFFTWPlan{$Tc,K,inplace,N}(X::StridedArray{$Tc,N},
                                               Y::StridedArray{$Tc,N},
                                               region, flags::Integer, timelimit::Real) where {K,inplace,N}
@@ -559,7 +560,7 @@ for (Tr,Tc,fftw,lib) in ((:Float64,:Complex128,"fftw",libfftw),
         if plan == C_NULL
             error("FFTW could not create plan") # shouldn't normally happen
         end
-        r2rFFTWPlan{$Tr,(map(Int,knd)...),inplace,N}(plan, flags, R, X, Y)
+        r2rFFTWPlan{$Tr,(map(Int,knd)...,),inplace,N}(plan, flags, R, X, Y)
     end
 
     # support r2r transforms of complex = transforms of real & imag parts
@@ -584,7 +585,7 @@ for (Tr,Tc,fftw,lib) in ((:Float64,:Complex128,"fftw",libfftw),
         if plan == C_NULL
             error("FFTW could not create plan") # shouldn't normally happen
         end
-        r2rFFTWPlan{$Tc,(map(Int,knd)...),inplace,N}(plan, flags, R, X, Y)
+        r2rFFTWPlan{$Tc,(map(Int,knd)...,),inplace,N}(plan, flags, R, X, Y)
     end
 
 end
@@ -594,8 +595,8 @@ end
 fftwcomplex(X::StridedArray{<:fftwComplex}) = X
 fftwcomplex(X::AbstractArray{T}) where {T<:fftwReal} =
     copy!(Array{typeof(complex(zero(T)))}(size(X)), X)
-fftwcomplex(X::AbstractArray{<:Real}) = copy!(Array{Complex128}(size(X)),X)
-fftwcomplex(X::AbstractArray{<:Complex}) = copy!(Array{Complex128}(size(X)), X)
+fftwcomplex(X::AbstractArray{<:Real}) = copy!(Array{Complex{Float64}}(size(X)),X)
+fftwcomplex(X::AbstractArray{<:Complex}) = copy!(Array{Complex{Float64}}(size(X)), X)
 fftwfloat(X::StridedArray{<:fftwReal}) = X
 fftwfloat(X::AbstractArray{<:Real}) = copy!(Array{Float64}(size(X)), X)
 fftwfloat(X::AbstractArray{<:Complex}) = fftwcomplex(X)
@@ -623,7 +624,7 @@ for (f,direction) in ((:fft,FORWARD), (:bfft,BACKWARD))
             $plan_f!(X, 1:ndims(X); kws...)
 
         function plan_inv(p::cFFTWPlan{T,$direction,inplace,N}) where {T<:fftwComplex,N,inplace}
-            X = Array{T}(p.sz)
+            X = Array{T}(undef, p.sz)
             Y = inplace ? X : fakesimilar(p.flags, X, T)
             ScaledPlan(cFFTWPlan{T,$idirection,inplace,N}(X, Y, p.region,
                                                           p.flags, NO_TIMELIMIT),
@@ -632,7 +633,7 @@ for (f,direction) in ((:fft,FORWARD), (:bfft,BACKWARD))
     end
 end
 
-function A_mul_B!(y::StridedArray{T}, p::cFFTWPlan{T}, x::StridedArray{T}) where T
+function mul!(y::StridedArray{T}, p::cFFTWPlan{T}, x::StridedArray{T}) where T
     assert_applicable(p, x, y)
     unsafe_execute!(p, x, y)
     return y
@@ -653,7 +654,7 @@ end
 
 # rfft/brfft and planned variants.  No in-place version for now.
 
-for (Tr,Tc) in ((:Float32,:Complex64),(:Float64,:Complex128))
+for (Tr,Tc) in ((:Float32,:(Complex{Float32})),(:Float64,:(Complex{Float64})))
     # Note: use $FORWARD and $BACKWARD below because of issue #9775
     @eval begin
         function plan_rfft(X::StridedArray{$Tr,N}, region;
@@ -704,12 +705,12 @@ for (Tr,Tc) in ((:Float32,:Complex64),(:Float64,:Complex128))
                        normalization(Y, p.region))
         end
 
-        function A_mul_B!(y::StridedArray{$Tc}, p::rFFTWPlan{$Tr,$FORWARD}, x::StridedArray{$Tr})
+        function mul!(y::StridedArray{$Tc}, p::rFFTWPlan{$Tr,$FORWARD}, x::StridedArray{$Tr})
             assert_applicable(p, x, y)
             unsafe_execute!(p, x, y)
             return y
         end
-        function A_mul_B!(y::StridedArray{$Tr}, p::rFFTWPlan{$Tc,$BACKWARD}, x::StridedArray{$Tc})
+        function mul!(y::StridedArray{$Tr}, p::rFFTWPlan{$Tc,$BACKWARD}, x::StridedArray{$Tc})
             assert_applicable(p, x, y)
             unsafe_execute!(p, x, y) # note: may overwrite x as well as y!
             return y
@@ -795,7 +796,7 @@ function plan_inv(p::r2rFFTWPlan{T,K,inplace,N}) where {T<:fftwNumber,K,inplace,
                              1:length(iK)))
 end
 
-function A_mul_B!(y::StridedArray{T}, p::r2rFFTWPlan{T}, x::StridedArray{T}) where T
+function mul!(y::StridedArray{T}, p::r2rFFTWPlan{T}, x::StridedArray{T}) where T
     assert_applicable(p, x, y)
     unsafe_execute!(p, x, y)
     return y

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,8 @@ using FFTW
 using FFTW: fftw_vendor
 using AbstractFFTs: Plan, plan_inv
 using Test
+using LinearAlgebra
+using Compat
 
 # Base Julia issue #19892
 # (test this first to make sure it happens before set_num_threads)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,12 +2,7 @@
 using FFTW
 using FFTW: fftw_vendor
 using AbstractFFTs: Plan, plan_inv
-
-if isdefined(Base, :Test) && !Base.isdeprecated(Base, :Test)
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 # Base Julia issue #19892
 # (test this first to make sure it happens before set_num_threads)
@@ -105,9 +100,9 @@ for (f,fi,pf,pfi) in ((fft,ifft,plan_fft,plan_ifft),
 
     sfftn_m4 = f(sm4)
     psfftn_m4 = pf(sm4)*sm4
-    sfft!n_b = map(Complex128,b)
+    sfft!n_b = map(Complex{Float64},b)
     sfft!n_m4 = view(sfft!n_b,3:6,9:12); fft!(sfft!n_m4)
-    psfft!n_b = map(Complex128,b)
+    psfft!n_b = map(Complex{Float64},b)
     psfft!n_m4 = view(psfft!n_b,3:6,9:12); plan_fft!(psfft!n_m4)*psfft!n_m4
 
     for i = 1:length(m4)
@@ -163,14 +158,14 @@ for (f,fi,pf,pfi) in ((fft,ifft,plan_fft,plan_ifft),
         pfft!d3_m3d = complex(m3d); plan_fft!(pfft!d3_m3d,3)*pfft!d3_m3d
         pifft!d3_fftd3_m3d = copy(fft!d3_m3d); plan_ifft!(pifft!d3_fftd3_m3d,3)*pifft!d3_fftd3_m3d
 
-        @test isa(fftd3_m3d, Array{Complex64,3})
-        @test isa(ifftd3_fftd3_m3d, Array{Complex64,3})
-        @test isa(fft!d3_m3d, Array{Complex64,3})
-        @test isa(ifft!d3_fftd3_m3d, Array{Complex64,3})
-        @test isa(pfftd3_m3d, Array{Complex64,3})
-        @test isa(pifftd3_fftd3_m3d, Array{Complex64,3})
-        @test isa(pfft!d3_m3d, Array{Complex64,3})
-        @test isa(pifft!d3_fftd3_m3d, Array{Complex64,3})
+        @test isa(fftd3_m3d, Array{Complex{Float32},3})
+        @test isa(ifftd3_fftd3_m3d, Array{Complex{Float32},3})
+        @test isa(fft!d3_m3d, Array{Complex{Float32},3})
+        @test isa(ifft!d3_fftd3_m3d, Array{Complex{Float32},3})
+        @test isa(pfftd3_m3d, Array{Complex{Float32},3})
+        @test isa(pifftd3_fftd3_m3d, Array{Complex{Float32},3})
+        @test isa(pfft!d3_m3d, Array{Complex{Float32},3})
+        @test isa(pifft!d3_fftd3_m3d, Array{Complex{Float32},3})
 
         for i = 1:length(m3d)
             @test fftd3_m3d[i] ≈ true_fftd3_m3d[i]
@@ -291,7 +286,7 @@ function fft_test(p::Plan{T}, ntrials=4,
     end
 end
 
-for T in (Complex64, Complex128)
+for T in (Complex{Float32}, Complex{Float64})
     for n in [1:100; 121; 143; 1000; 1024; 1031; 2000; 2048]
         x = zeros(T, n)
         fft_test(plan_fft(x))
@@ -300,7 +295,7 @@ for T in (Complex64, Complex128)
 end
 
 # test inversion, scaling, and pre-allocated variants
-for T in (Complex64, Complex128)
+for T in (Complex{Float32}, Complex{Float64})
     for x in (T[1:100;], copy(reshape(T[1:200;], 20,10)))
         y = similar(x)
         for planner in (plan_fft, plan_fft_, plan_ifft, plan_ifft_)
@@ -311,9 +306,9 @@ for T in (Complex64, Complex128)
             @test eltype(p) == eltype(pi) == eltype(p3) == eltype(p3i) == T
             @test vecnorm(x - p3i * (p * 3x)) < eps(real(T)) * 10000
             @test vecnorm(3x - pi * (p3 * x)) < eps(real(T)) * 10000
-            A_mul_B!(y, p, x)
+            mul!(y, p, x)
             @test y == p * x
-            A_ldiv_B!(y, p, x)
+            ldiv!(y, p, x)
             @test y == p \ x
         end
     end


### PR DESCRIPTION
Closes #56 and #58.

This includes a number of deprecation fixes, and bumps the minimum Julia version to be in sync with AbstractFFTs so that we can just rewrite the LinearAlgebra stuff entirely.