### PR TITLE
Fix deprecations on Julia 0.7

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.7.0-DEV.3449
 AbstractFFTs 0.3.0
 Reexport
-Compat 0.60.0
+Compat 0.62.0
 BinDeps 0.6.0

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -55,7 +55,7 @@ function plan_r2r end
 
 ## FFT: Implement fft by calling fftw.
 
-const version = convert(VersionNumber, split(unsafe_string(cglobal(
+const version = VersionNumber(split(unsafe_string(cglobal(
     (:fftw_version,libfftw), UInt8)), ['-', ' '])[2])
 
 ## Direction of FFT

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -488,7 +488,7 @@ end # fftw_vendor() != :mkl
 
 # test UNALIGNED flag
 let A = rand(Float32, 35), Ac = rand(Complex{Float32}, 35)
-    Y = Array{Complex{Float32}}(undef, 20)
+    local Y = Array{Complex{Float32}}(undef, 20)
     Yc = Array{Complex{Float32}}(undef, 35)
     planr = plan_rfft(Array{Float32}(undef, 32), flags=FFTW.UNALIGNED)
     planc = plan_fft(Array{Complex{Float32}}(undef, 32), flags=FFTW.UNALIGNED)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,8 +15,8 @@ let a = randn(10^5,1), p1 = plan_rfft(a, flags=FFTW.ESTIMATE)
     # make sure threads are actually being used for p2
     # (tests #21163).
     if FFTW.version >= v"3.3.4"
-        @test !contains(string(p1), "dft-thr")
-        @test contains(string(p2), "dft-thr")
+        @test !occursin("dft-thr", string(p1))
+        @test occursin("dft-thr", string(p2))
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -57,7 +57,7 @@ b[3:6,9:12] = m4
 sm4 = view(b,3:6,9:12)
 
 m3d = map(Float32,copy(reshape(1:5*3*2, 5, 3, 2)))
-true_fftd3_m3d = Array{Float32}(5, 3, 2)
+true_fftd3_m3d = Array{Float32}(undef, 5, 3, 2)
 true_fftd3_m3d[:,:,1] = 17:2:45
 true_fftd3_m3d[:,:,2] = -15
 


### PR DESCRIPTION
With one exception, these only affect the tests. We could even leave `REQUIRE` as is and introduce `test/REQUIRE` with the higher Compat version, but I don't think it's worth it.
All the `WARNING: Base.uninitialized is deprecated, use undef instead.` come from AbstractFFTs; they're fixed on master there, just not in the latest release.