### PR TITLE
Update FFTW.jl

### DIFF
--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module FFTW
 
 using Compat, LinearAlgebra, Reexport


### PR DESCRIPTION
Removed "__precompile__()", not needed in Julia 0.7: https://github.com/JuliaLang/julia/blob/0ef882679f00d331467b23ffe89906505f5774bf/NEWS.md

Throws warning here:
https://github.com/JuliaLang/julia/blob/dd248bf06c6d136ebc214c10f52730be362d290a/base/loading.jl#L780