### PR TITLE
Add Cirrus script to test the package on FreeBSD

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,17 @@
+freebsd_instance:
+  image: freebsd-12-0-release-amd64
+task:
+  name: FreeBSD
+  env:
+    matrix:
+      - JULIA_VERSION: 1.0
+      - JULIA_VERSION: 1.1
+      - JULIA_VERSION: nightly
+  install_script:
+    - sh -c "$(fetch https://raw.githubusercontent.com/ararslan/CirrusCI.jl/master/bin/install.sh -o -)"
+  build_script:
+    - cirrusjl build
+  test_script:
+    - cirrusjl test
+  coverage_script:
+    - cirrusjl coverage codecov coveralls


### PR DESCRIPTION
If someone with admin rights on this repo con [install Cirrus](https://github.com/marketplace/cirrus-ci), this PR enables testing for FreeBSD, which can be particularly useful for a package depending on a binary artifact.  Based on the [script](https://github.com/JuliaMath/SpecialFunctions.jl/blob/d8727a02d4cc5b34d2b3a1525c86869ef2a1104a/.cirrus.yml) for `SpecialFunctions.jl`