### PR TITLE
Fix warning on 1.1

### DIFF
--- a/deps/build_fftw.jl
+++ b/deps/build_fftw.jl
@@ -30,8 +30,8 @@ download_info = Dict(
 
 # Install unsatisfied or updated dependencies:
 unsatisfied = any(!satisfied(p; verbose=verbose) for p in products)
-if haskey(download_info, platform_key())
-    url, tarball_hash = download_info[platform_key()]
+if haskey(download_info, platform_key_abi())
+    url, tarball_hash = download_info[platform_key_abi()]
     if unsatisfied || !isinstalled(url, tarball_hash; prefix=prefix)
         # Download and install binaries
         install(url, tarball_hash; prefix=prefix, force=true, verbose=verbose)
@@ -40,7 +40,7 @@ elseif unsatisfied
     # If we don't have a BinaryProvider-compatible .tar.gz to download, complain.
     # Alternatively, you could attempt to install from a separate provider,
     # build from source or something even more ambitious here.
-    error("Your platform $(triplet(platform_key())) is not supported by this package!")
+    error("Your platform $(triplet(platform_key_abi())) is not supported by this package!")
 end
 
 # Write out a deps.jl file that will contain mappings for our products


### PR DESCRIPTION
```julia
┌ Warning: platform_key() is deprecated, use platform_key_abi() from now on
│   caller = ip:0x0
└ @ Core :-1
```
warning occurs while building FFTW on Julia 1.1. This should fix those warnings.
