### PR TITLE
Fixed link to AbstractFFTs in docs

### DIFF
--- a/docs/src/fft.md
+++ b/docs/src/fft.md
@@ -3,7 +3,7 @@
 This package extends the functionality provided by
 [AbstractFFTs](https://github.com/JuliaMath/AbstractFFTs.jl).
 To learn more about those functions, consult that package's
-[documentation](https://juliamath.github.io/AbstractFFTs.jl/stable/api.html).
+[documentation](https://juliamath.github.io/AbstractFFTs.jl/stable/api/).
 
 The following functions are unique to this package.
 


### PR DESCRIPTION
The documentation of AbstractFFTs has been moved to https://juliamath.github.io/AbstractFFTs.jl/stable/api/, however the documention of FFTW had not been updated. This commit updates that link. Fixes #101 