### PR TITLE
Restrict dependency version bounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ deps/builds
 docs/build
 docs/site
 .build_settings
+Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FFTW"
 uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "1.0.1"
+version = "1.1.0"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
@@ -9,12 +9,11 @@ Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-AbstractFFTs = "≥ 0.3.0"
-BinaryProvider = "≥ 0.3.0"
-julia = "^1.0.0"
+AbstractFFTs = "0.5"
+BinaryProvider = "0.5"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,10 +5,11 @@ fast Fourier transforms.
 
 ## Installation
 
-The package is available for Julia versions 0.6 and up.
+The package is available for Julia versions 1.0 and later.
 To install it, run
 
 ```julia
+using Pkg
 Pkg.add("FFTW")
 ```
 
@@ -22,16 +23,3 @@ after that, the package will remember to use MKL when building and updating.
 Note however that MKL provides only a subset of the functionality provided by FFTW. See
 Intel's [documentation](https://software.intel.com/en-us/mkl-developer-reference-c-using-fftw3-wrappers)
 for more information about potential differences or gaps in functionality.
-
-## Note
-
-These functions were formerly part of Base Julia.
-Should any name conflicts occur on Julia versions which include these functions,
-try adding
-
-```julia
-importall FFTW
-```
-
-to the top of your file.
-If the problem persists, please open an issue on this package's repository.


### PR DESCRIPTION
This pins AbstractFFTs and BinaryProvider to 0.5.x. Since FFTW reexports AbstractFFTs, breaking changes in AbstractFFTs propagates downstream via FFTW, as FFTW previously set only a lower bound on AbstractFFTs. In preparation for a release, this also sets the package version to 1.1.0.

This also has a separate commit that updates the documentation to be relevant to the 1.0 era.