### PR TITLE
Minor cleanup for Julia 1.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,6 +13,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 [compat]
 AbstractFFTs = "0.5"
 Conda = "1"
+FFTW_jll = "3.3"
 Reexport = "0.2"
 julia = "1.3"
 


### PR DESCRIPTION
This adds a missing compatibility entry for FFTW_jll and simplifies the checks for `Threads.@spawn` existing.