### PR TITLE
Fix windows MKL & add windows to travis (windows MKL wasn't being tested)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: julia
 os:
   - linux
   - osx
+  - windows
 julia:
   - 1.3
   - nightly

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -16,13 +16,14 @@ else
 end
 
 if provider == "MKL"
+    const mkllib = Sys.iswindows() ? "mkl_rt" : "libmkl_rt"
     # If BLAS was compiled with MKL and the user wants MKL-based FFTs, we'll oblige.
     if BLAS.vendor() === :mkl
-        mklpath = Libdl.dlpath("libmkl_rt")
+        mklpath = Libdl.dlpath(mkllib)
     else
         using Conda
         Conda.add("mkl_fft")
-        mklpath = joinpath(Conda.lib_dir(Conda.ROOTENV), "libmkl_rt")
+        mklpath = joinpath(Conda.lib_dir(Conda.ROOTENV), mkllib)
     end
     mklpath = escape_string(mklpath)
     isfile(depsfile) && rm(depsfile, force=true)

--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -24,7 +24,7 @@ else
 end
 
 # MKL provides its own FFTW
-const fftw_vendor = occursin("libmkl_rt", libfftw3) ? :mkl : :fftw
+const fftw_vendor = occursin("mkl_rt", libfftw3) ? :mkl : :fftw
 
 # Use Julia partr threading backend if present
 @static if fftw_vendor == :fftw


### PR DESCRIPTION
#127 adds travis to windows and tests MKL builds, which are failing.
On master, appveyor was missing MKL tests, so this just wasn't being tested