### PR TITLE
Add get_num_threads function

### DIFF
--- a/src/fft.jl
+++ b/src/fft.jl
@@ -108,6 +108,11 @@ const fftwSingle = Union{Float32,Complex{Float32}}
 const fftwTypeDouble = Union{Type{Float64},Type{Complex{Float64}}}
 const fftwTypeSingle = Union{Type{Float32},Type{Complex{Float32}}}
 
+# cached argument to set_num_threads
+
+# Default of 1 because set_num_threads is only called if Threads.nthreads() > 1
+const PLAN_NUM_THREADS = Ref(Int32(1))
+
 # For ESTIMATE plans, FFTW allows one to pass NULL for the array pointer,
 # since it is not written to.  Hence, it is convenient to create an
 # array-like type that carries a size and a stride like a "real" array
@@ -172,9 +177,12 @@ end
 # Threads
 
 function set_num_threads(nthreads::Integer)
+    PLAN_NUM_THREADS[] = nthreads # cache this argument for later access
     ccall((:fftw_plan_with_nthreads,libfftw3), Cvoid, (Int32,), nthreads)
     ccall((:fftwf_plan_with_nthreads,libfftw3f), Cvoid, (Int32,), nthreads)
 end
+
+get_num_threads() = PLAN_NUM_THREADS[]
 
 # pointer type for fftw_plan (opaque pointer)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -517,3 +517,8 @@ let a = randn(10^5,1)
         @test occursin("dft-thr", string(p2))
     end
 end
+
+FFTW.set_num_threads(1)
+@test FFTW.get_num_threads() == 1
+FFTW.set_num_threads(2)
+@test FFTW.get_num_threads() == 2


### PR DESCRIPTION
While it is possible to change the number of threads used by FFTW plans with
`set_num_threads`, it is impossible to see what the current value is. This is
made difficult because FFTW3 does not, as far as I know, provide a way to do
this. However, caching the last argument passed to `set_num_threads` as a
constant in FFTW.jl allows later access. I have added a constant,
`PLAN_NUM_THREADS` to keep track of the last argument to `set_num_threads`,
modified `set_num_threads` to update this constant, and added a function
`get_num_threads` to access the constant.

Closes #117