### PR TITLE
don't set nthreads > 1 by default

### DIFF
--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -57,7 +57,6 @@ function __init__()
             cspawnloop = @cfunction(spawnloop, Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}, Csize_t, Cint, Ptr{Cvoid}))
             ccall((:fftw_threads_set_callback,  libfftw3),  Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}), cspawnloop, C_NULL)
             ccall((:fftwf_threads_set_callback, libfftw3f), Cvoid, (Ptr{Cvoid}, Ptr{Cvoid}), cspawnloop, C_NULL)
-            set_num_threads(nthreads() * 4) # spawn more tasks than threads to help load-balancing
         end
     end
 end


### PR DESCRIPTION
Defaulting to multi-threaded FFTW was causing too many slowdowns in code that was calling FFTW in parallel from multiple threads (where the right thing is to use the serial FFTW, especially given Julia's current thread-spawning overhead).

Closes #121.  Closes JuliaDSP/DSP.jl#339.