### PR TITLE
Trying a delayed finalizer approach to fix threaded deadlock (#141)

### DIFF
--- a/src/fft.jl
+++ b/src/fft.jl
@@ -258,8 +258,7 @@ const DESTROY_QUEUE = Vector{FFTWPlan}(undef, 0)
 
 function destroy_queued_plans(t)
     while length(DESTROY_QUEUE) > 0
-        p = popfirst!(DESTROY_QUEUE)
-        destroy_plan(p)
+        destroy_plan(popfirst!(DESTROY_QUEUE)) # start with oldest
     end
     return nothing
 end
@@ -268,7 +267,7 @@ const DESTROY_QUEUE_TIMER = Ref{Timer}(Timer(destroy_queued_plans, 0))
 
 function queue_destroy_plan(p::FFTWPlan)
     push!(DESTROY_QUEUE, p) # add plan to destroy queue
-    close(DESTROY_QUEUE_TIMER[])
+    close(DESTROY_QUEUE_TIMER[]) # stop the existing timer
     DESTROY_QUEUE_TIMER[] = Timer(destroy_queued_plans, 5) # delay destroying plans by another 5 seconds
 end
 

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -272,10 +272,6 @@ function queue_destroy_plan(p::FFTWPlan)
     DESTROY_QUEUE_TIMER[] = Timer(destroy_queued_plans, 5) # delay destroying plans by another 5 seconds
 end
 
-
-    
-
-
 size(p::FFTWPlan) = p.sz
 
 unsafe_convert(::Type{PlanPtr}, p::FFTWPlan) = p.plan


### PR DESCRIPTION
Edit: Seems the julia crash was poor const handling that's now fixed.

Trying out @vtjnash’s suggestion from #141

> For now, I recommend only doing trivial things in a finalizer, like appending it to a queue to be cleaned up later.


This PR "fixes" the deadlock seen in the main DFTK example in #141 in the sense that the example finishes, ~~but when the queued & delayed finalizer runs, Julia crashes.~~ It's ~~obviously~~ _probably_ not a proper fix yet as I'm sure there's a better/correct/functional way to do this, but I thought I'd share my workings

```
using DFTK    
DFTK.FFTW.set_num_threads(Threads.nthreads() * 4)
    
function main()    
    for Ecut in 0.0 .+ collect(3:20)    
        println("Ecut = $Ecut")    
        a = 10.263141334305942    
        lattice = a / 2 .* [[0 1 1.]; [1 0 1.]; [1 1 0.]]    
        model = Model(lattice; terms=[Kinetic()], n_electrons=4)    
        basis = PlaneWaveBasis(model, Ecut)    
    end    
end    
    
@show Threads.nthreads()
main() 
```
```
Threads.nthreads() = 6
Ecut = 4.0
Ecut = 5.0
Ecut = 6.0
Ecut = 7.0
Ecut = 8.0
Ecut = 9.0
Ecut = 10.0
Ecut = 11.0
Ecut = 12.0
Ecut = 13.0
Ecut = 14.0
Ecut = 15.0
Ecut = 16.0
Ecut = 17.0
Ecut = 18.0
Ecut = 19.0
Ecut = 20.0
```

cc. @stevengj @vtjnash @mfherbst