### PR TITLE
Allow installing MKL_jll 2021

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   test:
+    timeout-minutes: 10
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - provider ${{ matrix.provider }} - ${{ matrix.threads }} thread(s)
     runs-on: ${{ matrix.os }}
     env:

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 AbstractFFTs = "1.0"
 FFTW_jll = "3.3"
 IntelOpenMP_jll = "2018.0.3"
-MKL_jll = "2019.0.117, 2020"
+MKL_jll = "2019.0.117, 2020, 2021"
 Reexport = "0.2, 1.0"
 julia = "1.3"
 


### PR DESCRIPTION
This should finally fix the failures on Windows with Julia nightly.