### PR TITLE
Adds version in deploydocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Coveralls](https://coveralls.io/repos/github/JuliaMath/FFTW.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaMath/FFTW.jl?branch=master)
 
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaMath.github.io/FFTW.jl/stable)
-[![](https://img.shields.io/badge/docs-latest-blue.svg)](https://JuliaMath.github.io/FFTW.jl/latest)
+[![](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaMath.github.io/FFTW.jl/dev)
 
 This package provides Julia bindings to the [FFTW](http://www.fftw.org/) library for
 fast Fourier transforms (FFTs), as well as functionality useful for signal processing.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,7 @@ makedocs(
 
 deploydocs(
     repo = "github.com/JuliaMath/FFTW.jl.git",
+    versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"],
     target = "build",
     deps = nothing,
     make = nothing,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,8 +12,5 @@ makedocs(
 
 deploydocs(
     repo = "github.com/JuliaMath/FFTW.jl.git",
-    versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"],
-    target = "build",
-    deps = nothing,
-    make = nothing,
+    versions = ["stable" => "v^", "v#.#.#", "dev" => "dev"]
 )


### PR DESCRIPTION
This is an attempt to deal with #185.

Unfortunately I don't think that I can push a docs preview, even if I set `push_preview = true` inside `deploydocs()` function so I don't have a way to figure out if this indeed deals with #185.