### PR TITLE
prevent to library from being serialized at precompile time

### DIFF
--- a/src/fft.jl
+++ b/src/fft.jl
@@ -552,8 +552,8 @@ end
 
 # low-level FFTWPlan creation (for internal use in FFTW module)
 
-for (Tr,Tc,fftw,lib) in ((:Float64,:(Complex{Float64}),"fftw",libfftw3),
-                         (:Float32,:(Complex{Float32}),"fftwf",libfftw3f))
+for (Tr,Tc,fftw,lib) in ((:Float64,:(Complex{Float64}),"fftw",:libfftw3),
+                         (:Float32,:(Complex{Float32}),"fftwf",:libfftw3f))
     @eval @exclusive function cFFTWPlan{$Tc,K,inplace,N}(X::StridedArray{$Tc,N},
                                               Y::StridedArray{$Tc,N},
                                               region, flags::Integer, timelimit::Real) where {K,inplace,N}


### PR DESCRIPTION
The interpolated variable `libfftw3` will evaluate at precompile time to the path to the local directory of the fftw library. This means that if you e.g. build a sysimage using FFTW and move it somewhere else that sysimage will not work properly. Instead, use `:libfftw3` which evaluates to the variable `libfftw3` which is set during runtime. This is likely what was originally intended.

cc @staticfloat @giordano @andreasnoack 