### PR TITLE
Update README to account for set_provider!

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,12 @@ The documentation of generic FFT functionality can be found in the [AbstractFFTs
 ## MKL
 
 Alternatively, the FFTs in Intel's Math Kernel Library (MKL) can be used
-by setting an environment variable `JULIA_FFTW_PROVIDER` to `MKL` and running
-`Pkg.build("FFTW")`. MKL will be provided through `MKL_jll`.
-Setting this environment variable only needs to be done for the first build of the package;
-after that, the package will remember to use MKL when building and updating.
+by running `FFTW.set_provider!("mkl")`. MKL will be provided through `MKL_jll`.
+This change of provider is persistent and has to be done only once, i.e., the package will use MKL when building and updating. 
 Note however that MKL provides only a subset of the functionality provided by FFTW. See
 Intel's [documentation](https://software.intel.com/en-us/mkl-developer-reference-c-using-fftw3-wrappers)
-for more information about potential differences or gaps in functionality.
+for more information about potential differences or gaps in functionality. 
+In case MKL does not fit the needs (anymore), `FFTW.set_provider!("fftw")` allows to revert the change of provider.
 
 
 ## License


### PR DESCRIPTION
The README of the repository still refers to the old provider interface based on the environment variable `JULIA_FFTW_PROVIDER` which has no effect anymore.