### PR TITLE
Add support for multidimensional complex vector fft bfft ifft for mkl.

### DIFF
--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -60,7 +60,7 @@ end
 
 include("fft.jl")
 include("dct.jl")
-if fftw_provider == "mkl"
+@static if fftw_provider == "mkl"
     include("mkl_patch.jl")
 end
 

--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -60,6 +60,9 @@ end
 
 include("fft.jl")
 include("dct.jl")
+if fftw_provider == "mkl"
+    include("mkl_patch.jl")
+end
 
 include("precompile.jl")
 _precompile_()

--- a/src/mkl_patch.jl
+++ b/src/mkl_patch.jl
@@ -1,0 +1,131 @@
+dims_howmany_for_loopplan(X::StridedArray, Y::StridedArray, plandims::Tuple{Vararg{Int}}) = begin
+    P = unique(plandims)
+    length(P) != length(plandims) &&
+        throw(ArgumentError("each dimension can be transformed at most once"))
+    reg, oreg  = P[1:end-1], P[end]
+    sz, ist, ost = collect.((size(X), strides(X), strides(Y)))
+    dims = Matrix(transpose([sz[reg] ist[reg] ost[reg]]))
+    howmany = Matrix(transpose([sz[oreg] ist[oreg] ost[oreg]]))
+    dims, howmany
+end
+# Although MKL's plan has no alignment limitation,
+# but the check is preseved here to keep similar behavior(throw the same error)
+mutable struct cLoopPlan{T,K,inplace,N,G,NW} <: FFTWPlan{T,K,inplace}
+    plan::PlanPtr
+    sz::NTuple{N,Int} # size of array on which plan operates (Int tuple)
+    osz::NTuple{N,Int} # size of output array (Int tuple)
+    istride::NTuple{N,Int} # strides of input
+    ostride::NTuple{N,Int} # strides of output
+    ialign::Int32 # alignment mod 16 of input
+    oalign::Int32 # alignment mod 16 of input
+    flags::UInt32 # planner flags
+    region::G # region (iterable) of dims that are transormed
+    loopdims::NTuple{NW,Int}
+    pinv::ScaledPlan
+    function cLoopPlan{T,K,inplace}(plan::PlanPtr, X, Y, region, flags, loopdims) where {T,K,inplace}
+        N, NW, G = ndims(X), length(loopdims), typeof(region)
+        p = new{T,K,inplace,N,G,NW}(plan, size(X), size(Y), strides(X), strides(Y),
+                                    alignment_of(X), alignment_of(Y), flags, region, loopdims)
+        finalizer(maybe_destroy_plan, p)
+        p
+    end
+end
+
+for (Tr,Tc,fftw,lib) in ((:Float64,:(Complex{Float64}),"fftw",:libfftw3),
+                         (:Float32,:(Complex{Float32}),"fftwf",:libfftw3f))
+    @eval @exclusive function cLoopPlan{$Tc,K,inplace}(X::StridedArray{$Tc,N},
+                                        Y::StridedArray{$Tc,N}, region, flags, timelimit) where {K,inplace,N}
+        unsafe_set_timelimit($Tr, timelimit)
+        plandims, loopdims = split_dim(X, region)
+        dims, howmany = dims_howmany_for_loopplan(X, Y, plandims)
+        plan = ccall(($(string(fftw,"_plan_guru64_dft")),$lib),
+                     PlanPtr,
+                     (Int32, Ptr{Int}, Int32, Ptr{Int},
+                      Ptr{$Tc}, Ptr{$Tc}, Int32, UInt32),
+                     size(dims,2), dims, size(howmany,2), howmany,
+                     X, Y, K, UNALIGNED) ## flags is useless
+        unsafe_set_timelimit($Tr, NO_TIMELIMIT)
+        if plan == C_NULL
+            error("FFTW could not create plan") # shouldn't normally happen
+        end
+        return cLoopPlan{$Tc,K,inplace}(plan, X, Y, region, flags, loopdims)
+    end
+end
+
+function split_dim(X, region)
+    dims = filter(i -> !in(i, region), 1:ndims(X))
+    # Determine which dimension to be planned by MKL's Dfti
+    # I believe the first dimension shoule be selected anyhow for columnmajor layout.
+    # Other dimensions might be selected based on size for better thread performance.
+    id = !in(1,region) || size(X,dims[1]) > 10Threads.nthreads() ?
+         1 : argmax(map(i -> size(X,i), dims))
+    loopdims = dims[[1:id-1;id+1:end]] |> NTuple{ndims(X) - length(region) - 1, Int}
+    plandims = (region..., dims[id])
+    plandims, loopdims
+end
+show(io::IO, p::cLoopPlan{T,K,inplace}) where {T,K,inplace} = begin
+    print(io, inplace ? "FFTW in-place " : "FFTW ",
+          K < 0 ? "forward" : "backward", " plan for ")
+    showfftdims(io, p.sz, p.istride, T)
+    has_sprint_plan && print(io, "\n", sprint_plan(p))
+end
+
+unsafe_loop_execute!(plan::cLoopPlan{T}, X::Ptr{T}, Y::Ptr{T}) where {T<:fftwComplex} = begin
+    if T <:fftwSingle
+        @ccall libfftw3f.fftwf_execute_dft(plan::PlanPtr, X::Ptr{T}, Y::Ptr{T})::Cvoid
+    else
+        @ccall libfftw3.fftw_execute_dft(plan::PlanPtr, X::Ptr{T}, Y::Ptr{T})::Cvoid
+    end
+end
+
+function unsafe_execute!(p::cLoopPlan{T}, x::StridedArray{T},
+                         y::StridedArray{T}) where {T <: fftwComplex}
+    loopistride = map(i -> p.istride[i], p.loopdims)
+    loopostride = map(i -> p.ostride[i], p.loopdims)
+    ax = map(i -> axes(x,i) .- first(axes(x,i)), p.loopdims)
+    Elsz, pointerˣ, pointerʸ = sizeof(T), pointer(x), pointer(y)
+    for ind in Iterators.product(ax...)
+        pointerˣ′ = pointerˣ + Elsz * sum(loopistride .* ind)
+        pointerʸ′ = pointerʸ + Elsz * sum(loopostride .* ind)
+        unsafe_loop_execute!(p, pointerˣ′, pointerʸ′)
+    end
+end
+
+function mul!(y::StridedArray{T,N}, p::cLoopPlan{T}, x::StridedArray{T,N}) where {T,N}
+    assert_applicable(p, x, y)
+    unsafe_execute!(p, x, y)
+    y
+end
+
+function *(p::cLoopPlan{T,K,inplace}, x::StridedArray{T,N}) where {T,K,N,inplace}
+    assert_applicable(p, x)
+    y = inplace ? x : Array{T,N}(undef, p.osz)
+    unsafe_execute!(p, x, y)
+    y
+end
+
+MightNeedLoop{T} = Union{StridedArray{T,3}, StridedArray{T,4}, StridedArray{T,5}, StridedArray{T,6}, StridedArray{T,7}}
+for inplace in (false,true)
+    for (f,direction) in ((:fft,FORWARD), (:bfft,BACKWARD))
+        plan_f = inplace ? Symbol("plan_",f,"!") : Symbol("plan_",f)
+        @eval $plan_f(X::MightNeedLoop{<:fftwComplex}, region; kws...) = $plan_f(X, Tuple(region); kws...)
+        # length information is needed for type stability, so I use ntuple here.
+        @eval $plan_f(X::MightNeedLoop{<:fftwComplex}; kws...) = $plan_f(X, ntuple(identity, ndims(X)); kws...)
+        @eval $plan_f(X::MightNeedLoop{<:fftwComplex}, region::Union{Integer,Tuple};
+                    flags::Integer=ESTIMATE,
+                    timelimit::Real=NO_TIMELIMIT) = begin
+            T, N = eltype(X), ndims(X)
+            Y = $inplace ? X : FakeArray{T}(size(X))
+            N <= length(region) + 1 && return cFFTWPlan{T,$direction,$inplace,N}(X, Y, region, flags, timelimit)
+            cLoopPlan{T,$direction,$inplace}(X, Y, region, flags, timelimit)
+        end
+        idirection = -direction
+        @eval function plan_inv(p::cLoopPlan{T,$direction,$inplace}) where {T<:fftwComplex}
+            X = Array{T}(undef, p.sz)
+            Y = $inplace ? X : FakeArray{T}(size(X))
+            ScaledPlan(cLoopPlan{T,$idirection,$inplace}(X, Y, p.region,
+                                                          p.flags, NO_TIMELIMIT),
+                       normalization(X, p.region))
+        end
+    end
+end

--- a/src/mkl_patch.jl
+++ b/src/mkl_patch.jl
@@ -111,7 +111,7 @@ function unsafe_execute!(p::cLoopPlan{T}, x::StridedArray{T},
     sz = (p.loopsz...,)
     istride = (p.loopistride...,)
     ostride = (p.loopostride...,)
-    unsafe_nd_execute!(p, , sz, istride, ostride)
+    unsafe_nd_execute!(p, X, Y, sz, istride, ostride)
 end
 
 function mul!(y::StridedArray{T,N}, p::cLoopPlan{T}, x::StridedArray{T,N}) where {T,N}

--- a/src/mkl_patch.jl
+++ b/src/mkl_patch.jl
@@ -37,7 +37,7 @@ dims_howmany_loopinfo(X::StridedArray, Y::StridedArray, region) = begin
         filter!(!in(sz₁dim), oreg)
     end
     dims = Matrix(transpose([sz[reg] ist[reg] ost[reg]]))
-    howmany, loopinfo = if length(oreg) == 0
+    howmany, loopinfo = if length(oreg) < 2
         Matrix(transpose([sz[oreg] ist[oreg] ost[oreg]])), (Int[], Int[], Int[])
     else
         howmany_loopinfo(sz[oreg], ist[oreg], ost[oreg])
@@ -79,9 +79,6 @@ for (Tr,Tc,fftw,lib) in ((:Float64,:(Complex{Float64}),"fftw",:libfftw3),
                                         Y::StridedArray{$Tc,N}, region, flags, timelimit) where {K,inplace,N}
         unsafe_set_timelimit($Tr, timelimit)
         dims, howmany, loopinfo = dims_howmany_loopinfo(X, Y, region)
-        println(dims)
-        println(howmany)
-        println(loopinfo)
         plan = ccall(($(string(fftw,"_plan_guru64_dft")),$lib),
                      PlanPtr,
                      (Int32, Ptr{Int}, Int32, Ptr{Int},

--- a/src/mkl_patch.jl
+++ b/src/mkl_patch.jl
@@ -4,7 +4,7 @@ might_reshape!(sz::Vector{Int}, ist::Vector{Int}, ost::Vector{Int}) = begin
         # fix for sz = (10,10) ist = (2,20) ost = (1,10)
         if sz[i] > 1 && sz[j] > 1 && (ist[i], ost[i]) .* sz[i] == (ist[j], ost[j])
             sz[i], sz[j] = sz[i] * sz[j], 1
-            return might_reshape!(sz, st)
+            return might_reshape!(sz, ist, ost)
         end
     end
     p = sz .> 1
@@ -12,7 +12,7 @@ might_reshape!(sz::Vector{Int}, ist::Vector{Int}, ost::Vector{Int}) = begin
 end
 
 howmany_loopinfo(sz::Vector{Int}, ist::Vector{Int}, ost::Vector{Int}) = begin
-    szʳ, istʳ, ostʳ = might_reshape!(sz[pick], ist[pick]) # try to reshape to reduce loop dims
+    szʳ, istʳ, ostʳ = might_reshape!(sz, ist, ost) # try to reshape to reduce loop dims
     ind = sortperm(tuple.(istʳ, ostʳ, .-szʳ))
     szˢ, istˢ, ostˢ = szʳ[ind], istʳ[ind], ostʳ[ind]
     pick = first(istˢ) == 1 ? 1 : findfirst(>(10Threads.nthreads()), szˢ) #how to improve?

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -528,3 +528,19 @@ end
         @test occursin("dft-thr", string(p2))
     end
 end
+if fftw_provider == "mkl"
+    @testset "MKL's multidimensional vector fft" begin
+        a = randn(ComplexF32,125,125,125)
+        b = ifft(a, 1)
+        @test reshape(b, 125, :) ≈ ifft(reshape(a, 125, :), 1)
+        a = ifft!(a, 1)
+        @test a ≈ b
+        a′ = @view a[:,1,:]
+        b′ = @view b[:,1,:]
+        p = FFTW.cFFTWPlan{ComplexF32,-1,false,2}(a′, b′, 2, FFTW.UNALIGNED, FFTW.NO_TIMELIMIT)
+        for i in 1:125
+          @views mul!(b[:,i,:],p,a[:,i,:])
+        end
+        @test fft(a, 3) ≈ b
+    end
+end


### PR DESCRIPTION
Some benchmark between fftw and mkl (with this PR)
```julia
a = randn(ComplexF32,2187,2187,100)
b = similar(a)
ps = plan_fft.(Ref(a), (1,2,3)) # without this PR, mkl will throw error.
#                      #fftw                                    --> mkl
@btime mul!(b,ps[1],a) #500.300 ms (57 allocations: 4.02 KiB)   --> 377.566 ms (0 allocations: 0 bytes)
@btime mul!(b,ps[2],a) #1.585 s (56 allocations: 3.98 KiB)      --> 703.885 ms (0 allocations: 0 bytes)
@btime mul!(b,ps[3],a) #475.970 ms (55 allocations: 3.95 KiB)   --> 409.303 ms (0 allocations: 0 bytes)
```
MKL has many other limitations. But I believe this is the most annoying one.
```julia
julia> versioninfo()
Julia Version 1.6.1
Commit 6aaedecc44 (2021-04-23 05:59 UTC)
Platform Info:
  OS: Windows (x86_64-w64-mingw32)
  CPU: Intel(R) Core(TM) i5-9600KF CPU @ 3.70GHz
  WORD_SIZE: 64
  LIBM: libopenlibm
  LLVM: libLLVM-11.0.1 (ORCJIT, skylake)
```