### PR TITLE
Add a safepoint in the maybe_destroy_plan spin lock

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FFTW"
 uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "1.4.1"
+version = "1.4.2"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -305,7 +305,7 @@ function maybe_destroy_plan(plan::FFTWPlan)
     # but we shouldn't waste too many cycles since destroying plans is quick and contention
     # should be rare.
     while !trylock(deferred_destroy_lock)
-        # Need a safepoint in here because without it, this loop block forward progress in the GC and can deadlock
+        # Need a safepoint in here because without it, this loop blocks forward progress in the GC and can deadlock
         # the program.
         GC.safepoint()
     end


### PR DESCRIPTION
This PR adds a safepoint in the `maybe_destroy_plan` spin lock to permit forward progress in that spin lock.
Without it, the spin lock blocks forward progress and can ultimately deadlock the program.
This was implemented according to [this observation](https://github.com/JuliaMath/FFTW.jl/issues/163#issuecomment-852444447).
I have tested this locally by running the minimum reproducible example; I can't get the program to deadlock any more.

I would like to write an automated test for this, but I can't think of one that would be reliable and run in a timely manner. My best method of testing this is running the minimal example code locally repeatedly and seeing if the program deadlocks.

Fixes #163.
