### PR TITLE
Make FFTW relocatable for PackageCompiler

### DIFF
--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -23,9 +23,17 @@ function __init__()
         Base.depwarn("JULIA_FFTW_PROVIDER is deprecated; use FFTW.set_provider!() instead", :JULIA_FFTW_PROVIDER)
     end
 
-    # Hook FFTW threads up to our partr runtime
+    # Hook FFTW threads up to our partr runtime, and re-assign the
+    # libfftw3{,f} refs at runtime, since we may have relocated and
+    # changed the path to the library since the last time we precompiled.
     @static if fftw_provider == "fftw"
         fftw_init_threads()
+        libfftw3[] = FFTW_jll.libfftw3_path
+        libfftw3f[] = FFTW_jll.libfftw3f_path
+    end
+    @static if fftw_provider == "mkl"
+        libfftw3[] = MKL_jll.libmkl_rt_path
+        libfftw3f[] = MKL_jll.libmkl_rt_path
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -507,7 +507,7 @@ end # fftw_provider == "fftw"
     end
 
     # check whether FFTW on this architecture has nontrivial alignment requirements
-    nontrivial_alignment = FFTW.fftw_provider == "fftw" && ccall((:fftwf_alignment_of, FFTW.libfftw3f), Int32, (Int,), 8) != 0
+    nontrivial_alignment = FFTW.fftw_provider == "fftw" && ccall((:fftwf_alignment_of, FFTW.libfftw3f[]), Int32, (Int,), 8) != 0
     if nontrivial_alignment
         @test_throws ArgumentError plan_rfft(Array{Float32}(undef, 32)) * view(A, 2:33)
         @test_throws ArgumentError plan_fft(Array{Complex{Float32}}(undef, 32)) * view(Ac, 2:33)


### PR DESCRIPTION
Because we need to know the FFTW vendor pretty early (at precompile
time to generate code, and at runtime) we need to load the path during
build (which bakes it into the precompile image), however we need to
update that path on next load within `__init__()` in case we're a part
of PackageCompiler and we need to be able to move things around without
requiring a recompile.  So we change all accesses of `libfftw3{,f}` to
be through a `Ref{String}()`, then update that ref within `__init__()`.

In the future, accesses of `FFTW_jll.libfftw3` will be through a
function, rather than a direct variable access, and we'll be able to get
these things for free, but that's still a ways down the line.