### PR TITLE
make FFTW relocatable, take 2

### DIFF
--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -27,9 +27,9 @@ function __init__()
     # libfftw3{,f} refs at runtime, since we may have relocated and
     # changed the path to the library since the last time we precompiled.
     @static if fftw_provider == "fftw"
-        fftw_init_threads()
         libfftw3[] = FFTW_jll.libfftw3_path
         libfftw3f[] = FFTW_jll.libfftw3f_path
+        fftw_init_threads()
     end
     @static if fftw_provider == "mkl"
         libfftw3[] = MKL_jll.libmkl_rt_path


### PR DESCRIPTION
`libfftw3` is used inside `fftw_init_threads()` so we need to update the paths first.

cc @staticfloat 