### PR TITLE
Minor performance improvements

### DIFF
--- a/src/fft.jl
+++ b/src/fft.jl
@@ -539,13 +539,7 @@ unsafe_execute!(plan::r2rFFTWPlan{T},
 # Compute dims and howmany for FFTW guru planner
 function dims_howmany(X::StridedArray, Y::StridedArray,
                       sz::Vector{Int}, region)
-    reg = if isa(region, Int)
-        region:region
-    elseif isa(region, Tuple)
-        Int[region...]
-    else
-        Int.(region)
-    end
+    reg = Int[region...]::Vector{Int}
     if length(unique(reg)) < length(reg)
         throw(ArgumentError("each dimension can be transformed at most once"))
     end

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -608,7 +608,7 @@ for (Tr,Tc,fftw,lib) in ((:Float64,:(Complex{Float64}),"fftw",:libfftw3),
                                                       Y::StridedArray{$Tr,N},
                                                       region, flags::Integer, timelimit::Real) where {inplace,N}
         R = isa(region, Tuple) ? region : copy(region)
-        region = isa(region, AbstractArray) ? circshift(region, -1) : region
+        region = isa(region, AbstractArray) ? circshift(region, -1) : region # FFTW halves last dim
         unsafe_set_timelimit($Tr, timelimit)
         dims, howmany = dims_howmany(X, Y, [size(Y)...], region)
         plan = ccall(($(string(fftw,"_plan_guru64_dft_c2r")),$lib[]),


### PR DESCRIPTION
Fixed a type inference issue with `dims_howmany`, removed a few other unneeded array allocations.

Using `imfilter` from ImageFiltering.jl, this is the result:

Before: 457.400 μs (173 allocations: 1.21 MiB)
After: 436.100 μs (130 allocations: 1.20 MiB)