### PR TITLE
In-place `irfft`/`brfft`

### DIFF
--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -12,7 +12,7 @@ import AbstractFFTs: Plan, ScaledPlan,
                      rfft_output_size, brfft_output_size,
                      plan_inv, normalization
 
-export dct, idct, dct!, idct!, plan_dct, plan_idct, plan_dct!, plan_idct!
+export dct, idct, dct!, idct!, plan_dct, plan_idct, plan_dct!, plan_idct!, brfft!, irfft!, plan_brfft!, plan_irfft!
 
 include("providers.jl")
 

--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -12,7 +12,7 @@ import AbstractFFTs: Plan, ScaledPlan,
                      rfft_output_size, brfft_output_size,
                      plan_inv, normalization
 
-export dct, idct, dct!, idct!, plan_dct, plan_idct, plan_dct!, plan_idct!, brfft!, irfft!, plan_brfft!, plan_irfft!, rfft!, plan_rfft!, PaddedRFFTArray
+export dct, idct, dct!, idct!, plan_dct, plan_idct, plan_dct!, plan_idct!, brfft!, irfft!, plan_brfft!, plan_irfft!
 
 include("providers.jl")
 

--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -12,7 +12,7 @@ import AbstractFFTs: Plan, ScaledPlan,
                      rfft_output_size, brfft_output_size,
                      plan_inv, normalization
 
-export dct, idct, dct!, idct!, plan_dct, plan_idct, plan_dct!, plan_idct!, brfft!, irfft!, plan_brfft!, plan_irfft!
+export dct, idct, dct!, idct!, plan_dct, plan_idct, plan_dct!, plan_idct!, brfft!, irfft!, plan_brfft!, plan_irfft!, rfft!, plan_rfft!, PaddedRFFTArray
 
 include("providers.jl")
 

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -610,7 +610,7 @@ for (Tr,Tc,fftw,lib) in ((:Float64,:(Complex{Float64}),"fftw",:libfftw3),
                                                      Y::StridedArray{$Tc,N},
                                                      region, flags::Integer, timelimit::Real) where {inplace,N}
         R = isa(region, Tuple) ? region : copy(region)
-        region = isa(region, AbstractArray) ? circshift(region, -1) : region # FFTW halves last dim
+        region = circshift(Int[region...],-1) # FFTW halves last dim
         unsafe_set_timelimit($Tr, timelimit)
         dims, howmany = dims_howmany(X, Y, [size(X)...], region)
         plan = ccall(($(string(fftw,"_plan_guru64_dft_r2c")),$lib[]),
@@ -630,7 +630,7 @@ for (Tr,Tc,fftw,lib) in ((:Float64,:(Complex{Float64}),"fftw",:libfftw3),
                                                       Y::StridedArray{$Tr,N},
                                                       region, flags::Integer, timelimit::Real) where {inplace,N}
         R = isa(region, Tuple) ? region : copy(region)
-        region = isa(region, AbstractArray) ? circshift(region, -1) : region # FFTW halves last dim
+        region = circshift(Int[region...],-1) # FFTW halves last dim
         unsafe_set_timelimit($Tr, timelimit)
         dims, howmany = dims_howmany(X, Y, [size(Y)...], region)
         plan = ccall(($(string(fftw,"_plan_guru64_dft_c2r")),$lib[]),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -529,50 +529,32 @@ end
     end
 end
 
-let a = rand(Float64,(8,4,4)), b = PaddedRFFTArray(a), c = copy(b)
+begin
     @testset "PaddedRFFTArray creation" begin
-      @test a == FFTW.real_view(b)
-      @test c == b
-      @test c.r == b.r
+        a = rand(Complex{Float64}, (8, 4, 4))
+        b = FFTW.PaddedRFFTArray(a)
+        c = copy(b)
+        @test a == FFTW.complex_view(b)
+        @test c == b
+        @test FFTW.real_view(c) == FFTW.real_view(b)
+        @test FFTW.complex_view(c) == FFTW.complex_view(b)
     end
     
-    @testset "rfft! and irfft!" begin
-      @test rfft(a) ≈ rfft!(b) 
-      @test a ≈ irfft!(b, size(a, 1))
-      @test rfft(a, 1:2) ≈ rfft!(b, 1:2) 
-      @test a ≈ irfft!(b, size(a, 1), 1:2)
-      # @test rfft(a, (1,3)) ≈ rfft!(b, (1,3)) fails 
-      # @test a ≈ irfft!(b, size(a, 1), (1,3))
-      
-      p = plan_rfft!(c)
-      @test p*c ≈ rfft!(b)
-      @test p\c ≈ irfft!(b, size(a, 1))
-    
-      a = rand(Float64, (9,4,4))
-      b = PaddedRFFTArray(a)
-      @test a == FFTW.real_view(b)
-      @test rfft(a) ≈ rfft!(b) 
-      @test a ≈ irfft!(b, size(a, 1))
-      @test rfft(a, 1:2) ≈ rfft!(b, 1:2) 
-      @test a ≈ irfft!(b, size(a, 1), 1:2)
-      # @test rfft(a, (1,3)) ≈ rfft!(b, (1,3)) # fails?
-      # @test a ≈ irfft!(b, size(a, 1), (1,3))
+    @testset "irfft!" begin
+        a = rand(Float64, (8, 4, 4))
+        c = rfft(a)
+        d = copy(c)
+        e = irfft!(d, size(a, 1))
+        @test a ≈ e
+        @test irfft(c, size(a, 1)) ≈ e
+        @test d === parent(parent(e))
+        @test d != c
+        @test irfft(c, size(a, 1), 1:2) ≈ irfft!(copy(c), size(a, 1), 1:2)
     end
     
     @testset "brfft!" begin
       a = rand(Float64,(4,4))
-      b = PaddedRFFTArray(a)
-      rfft!(b)
-      @test (brfft!(b) ./ 16) ≈ a
+      b = rfft(a)
+      @test (brfft!(b, size(a, 1)) ./ 16) ≈ a
     end
-    
-    @testset "FFTW MEASURE flag" begin
-      c = similar(b)
-      p = plan_rfft!(c,flags=FFTW.MEASURE)
-      p.pinv = plan_irfft!(c,flags=FFTW.MEASURE)
-      c .= b 
-      @test c == b
-      @test p*c ≈ rfft!(b)
-      @test p\c ≈ irfft!(b)
-    end
-end #let block
+end


### PR DESCRIPTION
Based on #54 and my attempted reworking of it, this is a subset of the functionality just to support a drop-in replacement of `irfft!` and `brfft!` for `irfft` and `brfft`.

It uses the `PaddedRFFTArray` type internally and returns a reinterpreted view of the input array containing the output.

`rfft!` is trickier to support and I ran into some issues with it, so I've cut that out for the moment but it could be added later.