### PR TITLE
Improve inferrability of dims_howmany

### DIFF
--- a/src/fft.jl
+++ b/src/fft.jl
@@ -514,8 +514,8 @@ unsafe_execute!(plan::r2rFFTWPlan{T},
 
 # Compute dims and howmany for FFTW guru planner
 function dims_howmany(X::StridedArray, Y::StridedArray,
-                      sz::Array{Int,1}, region)
-    reg = Int[region...]
+                      sz::Vector{Int}, region)
+    reg = Int[region...]::Vector{Int}
     if length(unique(reg)) < length(reg)
         throw(ArgumentError("each dimension can be transformed at most once"))
     end


### PR DESCRIPTION
This should be good for performance, and prevents dozens
of invalidations when loading packages like Interpolations
which add `eltype` methods.