### PR TITLE
Speclialize `lmul!` for plans

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FFTW"
 uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "1.5.0"
+version = "1.5.1"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -768,6 +768,10 @@ function *(p::cFFTWPlan{T,K,false}, x::StridedArray{T,N}) where {T,K,N}
 end
 
 function *(p::cFFTWPlan{T,K,true}, x::StridedArray{T}) where {T,K}
+    lmul!(p, x)
+end
+
+function LinearAlgebra.lmul!(p::cFFTWPlan{T,K,true}, x::StridedArray{T}) where {T,K}
     assert_applicable(p, x)
     unsafe_execute!(p, x, x)
     return x
@@ -980,6 +984,10 @@ function *(p::r2rFFTWPlan{T,K,false}, x::StridedArray{T,N}) where {T,K,N}
 end
 
 function *(p::r2rFFTWPlan{T,K,true}, x::StridedArray{T}) where {T,K}
+    lmul!(p, x)
+end
+
+function LinearAlgebra.lmul!(p::r2rFFTWPlan{T,K,true}, x::StridedArray{T}) where {T,K}
     assert_applicable(p, x)
     unsafe_execute!(p, x, x)
     return x


### PR DESCRIPTION
An in-place `plan * array` multiplication is perhaps better expressed as an `lmul!`, in analogy with `LinearAlgebra`. After this, the following will work
```julia
julia> v = rand(ComplexF64, 4);

julia> f = plan_fft!(v)
FFTW in-place forward plan for 4-element array of ComplexF64
(dft-direct-4 "n2fv_4_avx2_128")

julia> v2 = copy(v);

julia> lmul!(f, v);

julia> v == fft(v2)
true

```