### PR TITLE
Improve type inference in `plan_r2r`

### DIFF
--- a/src/fft.jl
+++ b/src/fft.jl
@@ -579,7 +579,7 @@ end
 # low-level FFTWPlan creation (for internal use in FFTW module)
 
 _mapIntknd(knd, region, kinds) = map(Int, knd)
-_mapIntknd(knd, region::AbstractUnitRange, kinds::Integer) = ntuple(x->Int(kinds), length(region))
+_mapIntknd(knd, region::Union{AbstractUnitRange,Tuple}, kinds::Integer) = ntuple(x->Int(kinds), length(region))
 
 for (Tr,Tc,fftw,lib) in ((:Float64,:(Complex{Float64}),"fftw",:libfftw3),
                          (:Float32,:(Complex{Float32}),"fftwf",:libfftw3f))

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -604,7 +604,7 @@ function fix_kinds(region, kinds)
     return k
 end
 fix_kinds(region::Tuple, kinds::Integer) = ntuple(_->Int32(kinds), length(region))
-fix_kinds(region::Tuple, kinds::Tuple{Integer}) = ntuple(_->Int32(kinds[1]), length(region))
+fix_kinds(region::Tuple, kinds::Tuple{Integer}) = fix_kinds(region, kinds[1])
 
 # Potentially avoid an extra `collect`
 _collect(T, x) = collect(T, x)

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -286,7 +286,7 @@ mutable struct r2rFFTWPlan{T<:fftwNumber,K,inplace,N,G} <: FFTWPlan{T,K,inplace}
     ialign::Int32 # alignment mod 16 of input
     oalign::Int32 # alignment mod 16 of input
     flags::UInt32 # planner flags
-    region::G # region (iterable) of dims that are transormed
+    region::G # region (iterable) of dims that are transformed
     kinds::K
     pinv::ScaledPlan
     function r2rFFTWPlan{T,K,inplace,N,G}(plan::PlanPtr, flags::Integer, R::G,

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -673,11 +673,10 @@ for (Tr,Tc,fftw,lib) in ((:Float64,:(Complex{Float64}),"fftw",:libfftw3),
         return rFFTWPlan{$Tc,$BACKWARD,inplace,N}(plan, flags, R, X, Y)
     end
 
-    @eval @exclusive function r2rFFTWPlan{$Tr,Any,inplace,N}(
-                                                X::StridedArray{$Tr,N},
-                                                Y::StridedArray{$Tr,N},
-                                                region, kinds, flags::Integer,
-                                                timelimit::Real) where {inplace,N}
+    @eval @exclusive function r2rFFTWPlan{$Tr,Any,inplace,N}(X::StridedArray{$Tr,N},
+                                                  Y::StridedArray{$Tr,N},
+                                                  region, kinds, flags::Integer,
+                                                  timelimit::Real) where {inplace,N}
 
         R = isa(region, Tuple) ? region : copy(region)
         knd = fix_kinds(region, kinds)
@@ -697,11 +696,10 @@ for (Tr,Tc,fftw,lib) in ((:Float64,:(Complex{Float64}),"fftw",:libfftw3),
     end
 
     # support r2r transforms of complex = transforms of real & imag parts
-    @eval @exclusive function r2rFFTWPlan{$Tc,Any,inplace,N}(
-                                                X::StridedArray{$Tc,N},
-                                                Y::StridedArray{$Tc,N},
-                                                region, kinds, flags::Integer,
-                                                timelimit::Real) where {inplace,N}
+    @eval @exclusive function r2rFFTWPlan{$Tc,Any,inplace,N}(X::StridedArray{$Tc,N},
+                                                  Y::StridedArray{$Tc,N},
+                                                  region, kinds, flags::Integer,
+                                                  timelimit::Real) where {inplace,N}
 
         R = isa(region, Tuple) ? region : copy(region)
         knd = fix_kinds(region, kinds)

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -245,7 +245,7 @@ end
 # needed to determine whether it is applicable.   We need to put
 # this into a type to support a finalizer on the fftw_plan.
 # K is FORWARD/BACKWARD for forward/backward or r2c/c2r plans, respectively.
-# For r2r plans, K is a tuple of the transform kinds along each dimension.
+# For r2r plans, the field kinds::K is a tuple/vector of the transform kinds along each dimension.
 abstract type FFTWPlan{T<:fftwNumber,K,inplace} <: Plan{T} end
 for P in (:cFFTWPlan, :rFFTWPlan) # complex, r2c/c2r
     @eval begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -552,3 +552,21 @@ end
     end
     @test FFTW.get_num_threads() == 2 # Unchanged
 end
+
+@testset "type-inference in r2r plans" begin
+    # Compare with definition
+    function testr2r(::Type{T}) where {T}
+        n = 4
+        v = T[1:n;]
+        plan = @static if VERSION >= v"1.7"
+            @inferred (() -> FFTW.plan_r2r(v, FFTW.REDFT10))()
+        else
+            FFTW.plan_r2r(v, FFTW.REDFT10)
+        end
+        @test plan * v ≈ [2sum(j->v[j+1]*cos(pi*(j+1/2)*k/n), 0:n-1) for k in 0:n-1]
+    end
+    testr2r(Float32)
+    testr2r(Float64)
+    testr2r(ComplexF32)
+    testr2r(ComplexF64)
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -565,8 +565,13 @@ end
         end
         @test plan * v ≈ [2sum(j->v[j+1]*cos(pi*(j+1/2)*k/n), 0:n-1) for k in 0:n-1]
     end
-    testr2r(Float32)
-    testr2r(Float64)
-    testr2r(ComplexF32)
-    testr2r(ComplexF64)
+    @testset for T in (Float32, Float64)
+        testr2r(T)
+    end
+    # complex r2r is broken on mkl
+    if FFTW.get_provider() == "fftw"
+        @testset for T in (ComplexF32, ComplexF64)
+            testr2r(T)
+        end
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -558,12 +558,11 @@ end
     function testr2r(::Type{T}) where {T}
         n = 4
         v = T[1:n;]
-        plan = @static if VERSION >= v"1.7"
-            @inferred (() -> FFTW.plan_r2r(v, FFTW.REDFT10))()
-        else
-            FFTW.plan_r2r(v, FFTW.REDFT10)
-        end
-        @test plan * v ≈ [2sum(j->v[j+1]*cos(pi*(j+1/2)*k/n), 0:n-1) for k in 0:n-1]
+        plan = @inferred (() -> FFTW.plan_r2r(v, FFTW.REDFT10))()
+        w = plan * v
+        @test w ≈ [2sum(j->v[j+1]*cos(pi*(j+1/2)*k/n), 0:n-1) for k in 0:n-1]
+        invplan = @inferred FFTW.plan_inv(plan)
+        @test invplan * w ≈ v
     end
     @testset for T in (Float32, Float64)
         testr2r(T)


### PR DESCRIPTION
## Updated PR

Instead of storing the value of `kinds` as a type parameter in `r2r` transforms, we may store it as a struct field instead, as this improves type-stability. This doesn't rely on the value being constant propagated.

## Older version of this PR

This is a somewhat hacky approach to improve type-inference in `plan_r2r`, in the case where `kinds` and `region` are compile-time constants. This is a common use case, so, for example, the following is type-stable after this:
```julia
julia> @inferred (() -> FFTW.plan_r2r(rand(4), FFTW.REDFT10))()
FFTW r2r REDFT10 plan for 4-element array of Float64
(redft10e-r2hc-4
  (rdft-r2hc-direct-r2c-4 "r2cf_4"))
```
The idea is that, in this case, the second type parameter of `r2rFFTWPlan` may be evaluated at compile time instead of a runtime call converting a `Vector` to a `Tuple`. This requires aggressive constant propagation through `Base.@constprop :aggressive`, which is not a part of the public API, but will hopefully be stable.