### PR TITLE
increase CI timeout

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 10
+    timeout-minutes: 30
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - provider ${{ matrix.provider }} - ${{ matrix.threads }} thread(s)
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
As seen e.g. in https://github.com/JuliaMath/FFTW.jl/actions/runs/4296128646/jobs/7487464311, cloning the repo may take close to 10 minutes, so setting a timeout of 10 minutes is unreasonable. This PR increases the timeout to 30 minutes.