### PR TITLE
remove tuple specialization of fix_kinds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FFTW"
 uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -603,12 +603,6 @@ function fix_kinds(region, kinds)
     end
     return k
 end
-fix_kinds(region::Tuple, kinds::Integer) = ntuple(_->Int32(kinds), length(region))
-fix_kinds(region::Tuple, kinds::Tuple{Integer}) = fix_kinds(region, kinds[1])
-
-# Potentially avoid an extra `collect`
-_collect(T, x) = collect(T, x)
-_collect(::Type{T}, x::AbstractVector) where {T} = convert(Vector{T}, x)
 
 # low-level FFTWPlan creation (for internal use in FFTW module)
 for (Tr,Tc,fftw,lib) in ((:Float64,:(Complex{Float64}),"fftw",:libfftw3),
@@ -687,7 +681,7 @@ for (Tr,Tc,fftw,lib) in ((:Float64,:(Complex{Float64}),"fftw",:libfftw3),
                      (Int32, Ptr{Int}, Int32, Ptr{Int},
                       Ptr{$Tr}, Ptr{$Tr}, Ptr{Int32}, UInt32),
                      size(dims,2), dims, size(howmany,2), howmany,
-                     X, Y, _collect(Int32, knd), flags)
+                     X, Y, knd, flags)
         unsafe_set_timelimit($Tr, NO_TIMELIMIT)
         if plan == C_NULL
             error("FFTW could not create plan") # shouldn't normally happen
@@ -713,7 +707,7 @@ for (Tr,Tc,fftw,lib) in ((:Float64,:(Complex{Float64}),"fftw",:libfftw3),
                      (Int32, Ptr{Int}, Int32, Ptr{Int},
                       Ptr{$Tc}, Ptr{$Tc}, Ptr{Int32}, UInt32),
                      size(dims,2), dims, size(howmany,2), howmany,
-                     X, Y, _collect(Int32, knd), flags)
+                     X, Y, knd, flags)
         unsafe_set_timelimit($Tr, NO_TIMELIMIT)
         if plan == C_NULL
             error("FFTW could not create plan") # shouldn't normally happen


### PR DESCRIPTION
This removes the `fix_kinds` method that evaluates to a `Tuple`. This was introduced in https://github.com/JuliaMath/FFTW.jl/pull/253 as a constant-propagation hack, but it's unnecessary now, given that the value is stored as a field rather than as a type-parameter. Having the method uniformly return a `Vector{Int32}` will firstly reduce unnecessary compilation, and secondly make the type parameters more predictable. The result has to be materialized in any case to create the plan, so this doesn't add to allocations.