### PR TITLE
reduce allocations in dims_howmany

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FFTW"
 uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "1.6.0"
+version = "1.7.0"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -566,19 +566,19 @@ unsafe_execute!(plan::r2rFFTWPlan{T},
 #    re-use the table of trigonometric constants from the first plan.
 
 # Compute dims and howmany for FFTW guru planner
+_collect_Intvector(x) = copyto!(Vector{Int}(undef, length(x)), x)
 function dims_howmany(X::StridedArray, Y::StridedArray,
                       sz::Vector{Int}, region)
-    reg = Int[region...]::Vector{Int}
+
+    reg = _collect_Intvector(region)
     if length(unique(reg)) < length(reg)
         throw(ArgumentError("each dimension can be transformed at most once"))
     end
-    ist = [strides(X)...]
-    ost = [strides(Y)...]
-    dims = Matrix(transpose([sz[reg] ist[reg] ost[reg]]))
-    oreg = [1:ndims(X);]
-    oreg[reg] .= 0
-    oreg = filter(d -> d > 0, oreg)
-    howmany = Matrix(transpose([sz[oreg] ist[oreg] ost[oreg]]))
+    ist = _collect_Intvector(strides(X))
+    ost = _collect_Intvector(strides(Y))
+    dims = vcat(view(sz, reg)', view(ist, reg)', view(ost, reg)')
+    oreg = [i for i in 1:ndims(X) if i ∉ reg]
+    howmany = vcat(view(sz, oreg)', view(ist, oreg)', view(ost, oreg)')
     return (dims, howmany)
 end
 

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -566,7 +566,6 @@ unsafe_execute!(plan::r2rFFTWPlan{T},
 #    re-use the table of trigonometric constants from the first plan.
 
 # Compute dims and howmany for FFTW guru planner
-_collect_Intvector(x) = copyto!(Vector{Int}(undef, length(x)), x)
 _anyrepeated(::Union{Number, AbstractUnitRange}) = false
 function _anyrepeated(region)
     any(region) do x
@@ -642,11 +641,9 @@ fix_kinds(region::Tuple, kinds::Tuple{Integer}) = fix_kinds(region, kinds[1])
 _collect(T, x) = collect(T, x)
 _collect(::Type{T}, x::AbstractVector) where {T} = convert(Vector{T}, x)
 
-_circshiftmin1(v::AbstractVector) = circshift(v, -1)
+_circshiftmin1(v) = circshift(collect(Int, v), -1)
 _circshiftmin1(t::Tuple) = (t[2:end]..., t[1])
 _circshiftmin1(x::Integer) = x
-# fallback for arbitrary iterators: convert to a vector first
-_circshiftmin1(v) = circshift(_collect_Intvector(v), -1)
 
 # low-level FFTWPlan creation (for internal use in FFTW module)
 for (Tr,Tc,fftw,lib) in ((:Float64,:(Complex{Float64}),"fftw",:libfftw3),

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -577,7 +577,7 @@ function dims_howmany(X::StridedArray, Y::StridedArray,
     ist = _collect_Intvector(strides(X))
     ost = _collect_Intvector(strides(Y))
     dims = vcat(view(sz, reg)', view(ist, reg)', view(ost, reg)')
-    oreg = [i for i in 1:ndims(X) if i ∉ reg]
+    oreg = filter(∉(reg), 1:ndims(X))
     howmany = vcat(view(sz, oreg)', view(ist, oreg)', view(ost, oreg)')
     return (dims, howmany)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -181,6 +181,9 @@ true_fftd3_m3d[:,:,2] .= -15
 end
 
 @testset "rfft/rfftn" begin
+    # Test regions as int/collection
+    @test rfft(m4,1) == rfft(m4,1:1) == rfft(m4,(1,)) == rfft(m4, [1])
+
     rfft_m4 = rfft(m4,1)
     rfftd2_m4 = rfft(m4,2)
     rfftn_m4 = rfft(m4)


### PR DESCRIPTION
This reduces some unnecessary allocations in `dims_howmany`. This may be reduced further  by using `StaticArrays`, but that's a separate discussion as it'll increase the load time.

On master
```julia
julia> X = rand(100, 100);

julia> @btime FFTW.dims_howmany($X, $X, $(collect(size(X))), 1)
  689.000 ns (21 allocations: 1.59 KiB)
([100; 1; 1;;], [100; 100; 100;;])
```
This PR
Updated after https://github.com/JuliaMath/FFTW.jl/pull/269/commits/e15a9b8c8576a714f95d70cf32edf093c0b647a1
```julia
julia> @btime FFTW.dims_howmany($X, $X, size($X), 1);
  73.707 ns (2 allocations: 160 bytes)
```