### PR TITLE
Increase CI timeout length

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test:
-    timeout-minutes: 15
+    timeout-minutes: 30
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - provider ${{ matrix.provider }} - ${{ matrix.threads }} thread(s)
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
Some of the CI tests can stochastically take much longer than the expected runtime (around 3min), so this PR bumps the timeout period to avoid spurious CI failures