### PR TITLE
Check and use only available FFTW libraries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FFTW"
 uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "1.7.1"
+version = "1.7.2"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -11,6 +11,8 @@ import AbstractFFTs: Plan, ScaledPlan,
                      fftshift, ifftshift,
                      rfft_output_size, brfft_output_size,
                      plan_inv, normalization
+import FFTW_jll
+import MKL_jll
 
 export dct, idct, dct!, idct!, plan_dct, plan_idct, plan_dct!, plan_idct!
 

--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -11,8 +11,6 @@ import AbstractFFTs: Plan, ScaledPlan,
                      fftshift, ifftshift,
                      rfft_output_size, brfft_output_size,
                      plan_inv, normalization
-import FFTW_jll
-import MKL_jll
 
 export dct, idct, dct!, idct!, plan_dct, plan_idct, plan_dct!, plan_idct!
 

--- a/src/providers.jl
+++ b/src/providers.jl
@@ -1,25 +1,27 @@
-# Hardcoded list of supported platforms
-# In principle, we could check FFTW_jll.is_available() and MKL_jll.is_available()
-# but then we would have to load MKL_jll which we want to avoid (lazy artifacts!)
-const platforms_providers = Dict(
-    Base.BinaryPlatforms.Platform("aarch64", "macos") => ("fftw",),
-    Base.BinaryPlatforms.Platform("aarch64", "linux"; libc = "glibc") => ("fftw",),
-    Base.BinaryPlatforms.Platform("aarch64", "linux"; libc = "musl") => ("fftw",),
-    Base.BinaryPlatforms.Platform("armv6l", "linux"; libc = "glibc", call_abi = "eabihf") => ("fftw",),
-    Base.BinaryPlatforms.Platform("armv6l", "linux"; libc = "musl", call_abi = "eabihf") => ("fftw",),
-    Base.BinaryPlatforms.Platform("armv7l", "linux"; libc = "glibc", call_abi = "eabihf") => ("fftw",),
-    Base.BinaryPlatforms.Platform("armv7l", "linux"; libc = "musl", call_abi = "eabihf") => ("fftw",),
-    Base.BinaryPlatforms.Platform("i686", "linux"; libc = "glibc") => ("fftw", "mkl"),
-    Base.BinaryPlatforms.Platform("i686", "linux"; libc = "musl") => ("fftw",),
-    Base.BinaryPlatforms.Platform("i686", "windows") => ("fftw", "mkl"),
-    Base.BinaryPlatforms.Platform("powerpc64le", "linux"; libc = "glibc") => ("fftw",),
-    Base.BinaryPlatforms.Platform("x86_64", "macos") => ("fftw", "mkl"),
-    Base.BinaryPlatforms.Platform("x86_64", "linux"; libc = "glibc") => ("fftw",),
-    Base.BinaryPlatforms.Platform("x86_64", "linux"; libc = "musl") => ("fftw",),
-    Base.BinaryPlatforms.Platform("x86_64", "freebsd") => ("fftw",),
-    Base.BinaryPlatforms.Platform("x86_64", "windows") => ("fftw", "mkl"),
-)
-const valid_fftw_providers = Base.BinaryPlatforms.select_platform(platforms_providers, Base.BinaryPlatforms.HostPlatform())
+const valid_fftw_providers = let
+    # Hardcoded list of supported platforms
+    # In principle, we could check FFTW_jll.is_available() and MKL_jll.is_available()
+    # but then we would have to load MKL_jll which we want to avoid (lazy artifacts!)
+    platforms_providers = Dict(
+        Base.BinaryPlatforms.Platform("aarch64", "macos") => ("fftw",),
+        Base.BinaryPlatforms.Platform("aarch64", "linux"; libc = "glibc") => ("fftw",),
+        Base.BinaryPlatforms.Platform("aarch64", "linux"; libc = "musl") => ("fftw",),
+        Base.BinaryPlatforms.Platform("armv6l", "linux"; libc = "glibc", call_abi = "eabihf") => ("fftw",),
+        Base.BinaryPlatforms.Platform("armv6l", "linux"; libc = "musl", call_abi = "eabihf") => ("fftw",),
+        Base.BinaryPlatforms.Platform("armv7l", "linux"; libc = "glibc", call_abi = "eabihf") => ("fftw",),
+        Base.BinaryPlatforms.Platform("armv7l", "linux"; libc = "musl", call_abi = "eabihf") => ("fftw",),
+        Base.BinaryPlatforms.Platform("i686", "linux"; libc = "glibc") => ("fftw", "mkl"),
+        Base.BinaryPlatforms.Platform("i686", "linux"; libc = "musl") => ("fftw",),
+        Base.BinaryPlatforms.Platform("i686", "windows") => ("fftw", "mkl"),
+        Base.BinaryPlatforms.Platform("powerpc64le", "linux"; libc = "glibc") => ("fftw",),
+        Base.BinaryPlatforms.Platform("x86_64", "macos") => ("fftw", "mkl"),
+        Base.BinaryPlatforms.Platform("x86_64", "linux"; libc = "glibc") => ("fftw",),
+        Base.BinaryPlatforms.Platform("x86_64", "linux"; libc = "musl") => ("fftw",),
+        Base.BinaryPlatforms.Platform("x86_64", "freebsd") => ("fftw",),
+        Base.BinaryPlatforms.Platform("x86_64", "windows") => ("fftw", "mkl"),
+    )
+    Base.BinaryPlatforms.select_platform(platforms_providers, Base.BinaryPlatforms.HostPlatform())
+end
 if valid_fftw_providers === nothing
     error("no valid FFTW library available")
 end
@@ -76,7 +78,7 @@ end
     if !FFTW_jll.is_available()
         # more descriptive error message if FFTW is not available
         # (should not be possible to reach this)
-        error("FFTW library cannot be loaded: please switch to the `mkl` provider for FFTW.jl")
+        @error("FFTW library cannot be loaded: Run `FFTW.set_provider!(\"mkl\")` to switch to MKL")
     end
     libfftw3[] = FFTW_jll.libfftw3_path
     libfftw3f[] = FFTW_jll.libfftw3f_path
@@ -116,7 +118,7 @@ end
     if !MKL_jll.is_available()
         # more descriptive error message if MKL is not available
         # (should not be possible to reach this)
-        error("MKL library cannot be loaded: please switch to the `fftw` provider for FFTW.jl")
+        @error("MKL cannot be loaded: Run `FFTW.set_provider!(\"fftw\")` to switch to the FFTW library")
     end
     libfftw3[] = MKL_jll.libmkl_rt_path
     libfftw3f[] = MKL_jll.libmkl_rt_path


### PR DESCRIPTION
I think it would be good to check if FFTW_jll and MKL_jll are actually available before trying to load them, as suggested in https://github.com/JuliaMath/FFTW.jl/issues/274#issuecomment-1618774373. I ran into this issue with a project that specified `provider = "mkl"` in a LocalPreferences.toml - precompilation will error on my MacBook since MKL is not available for Apple silicon. With this PR, FFTW will use FFTW_jll instead (if it's not available either an error is thrown) but present the user with the error message:
```julia
┌ FFTW [7a1cc6ca-52ef-59f5-83cd-3a7055c09341]
│  ┌ Error: Invalid provider setting "mkl"; valid settings include ["fftw"]
│  └ @ FFTW ~/.julia/dev/FFTW/src/providers.jl:23
└
```

Fixes https://github.com/JuliaMath/FFTW.jl/issues/274.