### PR TITLE
Allow MKL_jll v2024

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,7 +13,7 @@ Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 [compat]
 AbstractFFTs = "1.5"
 FFTW_jll = "3.3.9"
-MKL_jll = "2019.0.117, 2020, 2021, 2022, 2023"
+MKL_jll = "2019.0.117, 2020, 2021, 2022, 2023, 2024"
 Preferences = "1.2"
 Reexport = "0.2, 1.0"
 julia = "1.6"


### PR DESCRIPTION
This is what's causing https://github.com/SciML/NonlinearSolve.jl/issues/316. There must be a better way than versioning this every year?