### PR TITLE
CompatHelper: make PRs to bump JLL compat entries

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Pkg.add("CompatHelper")
         run: julia -e 'using Pkg; Pkg.add("CompatHelper")'
-      - name: CompatHelper.main()
+      - name: CompatHelper.main(; include_jll = true)
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: julia -e 'using CompatHelper; CompatHelper.main()'


### PR DESCRIPTION
Ref #283 

By default, CompatHelper does not make PRs to add or update `[compat]` entries for JLL packages.

However, if you want CompatHelper PRs for JLL packages, you can opt-into this behavior by setting `include_jll = true`.