### PR TITLE
CI: for the macOS CI jobs with the MKL provider, force MKL_jll 2023 to be installed

### DIFF
--- a/.ci/macos_mkl_2023.jl
+++ b/.ci/macos_mkl_2023.jl
@@ -1,0 +1,32 @@
+# In MKL 2024, Intel dropped support for macOS.
+# So, in CI, for the macOS jobs, we force MKL 2023 to be installed (instead of
+# MKL 2024).
+
+import TOML
+
+using Test: @test
+
+function main()
+    root_dotci_dir = @__DIR__
+    root_dir = dirname(root_dotci_dir)
+    root_project_toml_filename = joinpath(root_dir, "Project.toml")
+    project = TOML.parsefile(root_project_toml_filename)
+    old_mkl_jll_compat = project["compat"]["MKL_jll"]
+    old_mkl_jll_compat_list = strip.(split(strip(old_mkl_jll_compat), ","))
+
+    # Regression test to catch if we ever drop support for MKL_jll 2023.
+    # Because, if we ever do choose to drop support for MKL_jll 2023, then this
+    # entire script should probably be deleted, since Intel dropped support for
+    # macOS in MKL 2024.
+    @test "2023" in old_mkl_jll_compat_list
+
+    new_compat = "2023"
+    project["compat"]["MKL_jll"] = new_compat # force MKL_jll 2023
+    open(root_project_toml_filename, "w") do io
+        TOML.print(io, project)
+    end
+    @info "Changed the compat entry for MKL_jll to: $(new_compat)"
+    return nothing
+end
+
+main()

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,6 +49,7 @@ jobs:
             arch: x86
           - provider: 'mkl'
             threads: '2'
+
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,10 +49,6 @@ jobs:
             arch: x86
           - provider: 'mkl'
             threads: '2'
-          # In MKL 2024, Intel dropped support for macOS.
-          - os: macOS-latest
-            provider: 'mkl'
-
     steps:
       - uses: actions/checkout@v3
       - uses: julia-actions/setup-julia@v1
@@ -60,6 +56,11 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
+      # In MKL 2024, Intel dropped support for macOS.
+      # So, in CI, for the macOS jobs, we force MKL 2023 to be installed (instead of
+      # MKL 2024).
+      - run: julia .ci/macos_mkl_2023.jl
+        if: (matrix.os == 'macOS-latest') && (matrix.provider == 'mkl')
       - name: Set Preferences
         run: julia --project .github/set_ci_preferences.jl "${{ matrix.provider }}"
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,6 +49,9 @@ jobs:
             arch: x86
           - provider: 'mkl'
             threads: '2'
+          # In MKL 2024, Intel dropped support for macOS.
+          - os: macOS-latest
+            provider: 'mkl'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
In MKL 2024, Intel dropped support for macOS.