### PR TITLE
Update CI.yml for Apple Silicon

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,15 +61,16 @@ jobs:
             arch: x86
           - os: macOS-13
             arch: aarch64
+          - os: macOS-13
+            version: '1.6'
+            provider: 'mkl'
           - os: macOS-14
             arch: x86
           - os: macOS-14
             arch: x64
           - os: macOS-14
-            arch: aarch64
             version: '1.6'
           - os: macOS-14
-            arch: aarch64
             provider: 'mkl'
             
     steps:
@@ -83,7 +84,7 @@ jobs:
       # So, in CI, for the macOS jobs, we force MKL 2023 to be installed (instead of
       # MKL 2024).
       - run: julia .ci/macos_mkl_2023.jl
-        if: (matrix.os == 'macOS-latest') && (matrix.provider == 'mkl')
+        if: (matrix.os == 'macOS-13') && (matrix.provider == 'mkl')
       - name: Set Preferences
         run: julia --project .github/set_ci_preferences.jl "${{ matrix.provider }}"
       - uses: julia-actions/julia-runtest@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,6 +61,7 @@ jobs:
             arch: x86
           - os: macOS-13
             arch: aarch64
+          - 
           - os: macOS-14
             arch: x86
           - os: macOS-14
@@ -68,6 +69,9 @@ jobs:
           - os: macOS-14
             arch: aarch64
             version: '1.6'
+          - os: macOS-14
+            arch: aarch64
+            provider: 'mkl'
             
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,7 +61,6 @@ jobs:
             arch: x86
           - os: macOS-13
             arch: aarch64
-          - 
           - os: macOS-14
             arch: x86
           - os: macOS-14

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,14 +32,16 @@ jobs:
           - 'nightly'
         os:
           - ubuntu-latest
-          - macOS-latest
           - windows-latest
+          - macOS-13 # intel
+          - macOS-14 # arm
         threads:
           - '1'
           - '2'
         arch:
           - x64
           - x86
+          - aarch64
         exclude:
           # 32-bit Julia binaries are not available on macOS
           - os: macOS-latest
@@ -50,7 +52,23 @@ jobs:
             arch: x86
           - provider: 'mkl'
             threads: '2'
-
+          # Disable various OS-arch combinations that are not available 
+          - os: ubuntu-latest
+            arch: aarch64
+          - os: windows-latest
+            arch: aarch64
+          - os: macOS-13
+            arch: x86
+          - os: macOS-13
+            arch: aarch64
+          - os: macOS-14
+            arch: x86
+          - os: macOS-14
+            arch: x64
+          - os: macOS-14
+            arch: aarch64
+            version: '1.6'
+            
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v1


### PR DESCRIPTION
Enabling Apple Silicon is a bit messy because of the cross product of all platforms. It's good to be able to test it though, and happy to improve the script if anyone has suggestions for simplification.

Is it useful to run all the tests on Julia nightly? I feel we can save CI time by removing nightly.