### PR TITLE
Move MKL to an extension on 1.9+

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,11 @@
 name = "FFTW"
 uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "1.8"
+version = "2.0.0"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 FFTW_jll = "f5851436-0d7a-5f13-b9de-f02708fd171a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 
@@ -18,3 +17,12 @@ MKL_jll = "2019.0.117, 2020, 2021, 2022, 2023, 2024"
 Preferences = "1.2"
 Reexport = "0.2, 1.0"
 julia = "1.6"
+
+[extensions]
+FFTWMKLExt = ["MKL_jll"]
+
+[weakdeps]
+MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
+
+[extras]
+MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7"

--- a/Project.toml
+++ b/Project.toml
@@ -21,8 +21,8 @@ julia = "1.6"
 [extensions]
 FFTWMKLExt = ["MKL_jll"]
 
-[weakdeps]
+[extras]
 MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
 
-[extras]
+[weakdeps]
 MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7"

--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ The documentation of generic FFT functionality can be found in the [AbstractFFTs
 
 Alternatively, the FFTs in Intel's Math Kernel Library (MKL) can be used
 by running `FFTW.set_provider!("mkl")`. MKL will be provided through `MKL_jll`.
-This change of provider is persistent and has to be done only once, i.e., the package will use MKL when building and updating. 
+On Julia 1.9+, this functionality is provided as an extension and so either `MKL` or `MKL_jll` must be explicitly loaded.
+This change of provider is persistent and has to be done only once, i.e., the package will use MKL when building and updating.
 Note however that MKL provides only a subset of the functionality provided by FFTW. See
 Intel's [documentation](https://software.intel.com/en-us/mkl-developer-reference-c-using-fftw3-wrappers)
-for more information about potential differences or gaps in functionality. 
+for more information about potential differences or gaps in functionality.
 In case MKL does not fit the needs (anymore), `FFTW.set_provider!("fftw")` allows to revert the change of provider.
 
 

--- a/ext/FFTWMKLExt.jl
+++ b/ext/FFTWMKLExt.jl
@@ -1,0 +1,22 @@
+module FFTWMKLExt
+
+using FFTW
+
+# If we're using MKL, load it in and set library paths appropriately.
+@static if fftw_provider == "mkl"
+    import MKL_jll
+    FFTW.libfftw3[] = MKL_jll.libmkl_rt_path
+    FFTW.libfftw3f[] = MKL_jll.libmkl_rt_path
+end
+
+function __init__()
+    # Hook FFTW threads up to our partr runtime, and re-assign the
+    # libfftw3{,f} refs at runtime, since we may have relocated and
+    # changed the path to the library since the last time we precompiled.
+    @static if fftw_provider == "mkl"
+        FFTW.libfftw3[] = MKL_jll.libmkl_rt_path
+        FFTW.libfftw3f[] = MKL_jll.libmkl_rt_path
+    end
+end
+
+end

--- a/ext/FFTWMKLExt.jl
+++ b/ext/FFTWMKLExt.jl
@@ -7,6 +7,8 @@ using FFTW
     import MKL_jll
     FFTW.libfftw3[] = MKL_jll.libmkl_rt_path
     FFTW.libfftw3f[] = MKL_jll.libmkl_rt_path
+    FFTW.version[] = VersionNumber(split(unsafe_string(cglobal(
+                                    (:fftw_version,FFTW.libfftw3[]), UInt8)), ['-', ' '])[2])
 end
 
 function __init__()
@@ -16,6 +18,8 @@ function __init__()
     @static if FFTW.fftw_provider == "mkl"
         FFTW.libfftw3[] = MKL_jll.libmkl_rt_path
         FFTW.libfftw3f[] = MKL_jll.libmkl_rt_path
+        FFTW.version[] = VersionNumber(split(unsafe_string(cglobal(
+                                (:fftw_version,FFTW.libfftw3[]), UInt8)), ['-', ' '])[2])
     end
 end
 

--- a/ext/FFTWMKLExt.jl
+++ b/ext/FFTWMKLExt.jl
@@ -3,7 +3,7 @@ module FFTWMKLExt
 using FFTW
 
 # If we're using MKL, load it in and set library paths appropriately.
-@static if fftw_provider == "mkl"
+@static if FFTW.fftw_provider == "mkl"
     import MKL_jll
     FFTW.libfftw3[] = MKL_jll.libmkl_rt_path
     FFTW.libfftw3f[] = MKL_jll.libmkl_rt_path
@@ -13,7 +13,7 @@ function __init__()
     # Hook FFTW threads up to our partr runtime, and re-assign the
     # libfftw3{,f} refs at runtime, since we may have relocated and
     # changed the path to the library since the last time we precompiled.
-    @static if fftw_provider == "mkl"
+    @static if FFTW.fftw_provider == "mkl"
         FFTW.libfftw3[] = MKL_jll.libmkl_rt_path
         FFTW.libfftw3f[] = MKL_jll.libmkl_rt_path
     end

--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -14,6 +14,8 @@ import AbstractFFTs: Plan, ScaledPlan,
 
 export dct, idct, dct!, idct!, plan_dct, plan_idct, plan_dct!, plan_idct!
 
+const _last_num_threads = Ref(Cint(1))
+
 include("providers.jl")
 
 function __init__()
@@ -30,10 +32,6 @@ function __init__()
         libfftw3[] = FFTW_jll.libfftw3_path
         libfftw3f[] = FFTW_jll.libfftw3f_path
         fftw_init_threads()
-    end
-    @static if fftw_provider == "mkl"
-        libfftw3[] = MKL_jll.libmkl_rt_path
-        libfftw3f[] = MKL_jll.libmkl_rt_path
     end
 end
 
@@ -68,6 +66,11 @@ end
 
 include("fft.jl")
 include("dct.jl")
+
+@static if !isdefined(Base, :get_extension)
+    include("../ext/FFTWMKLExt.jl")
+    using .FFTWMKLExt
+end
 
 include("precompile.jl")
 _precompile_()

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -54,10 +54,12 @@ correspond to [`r2r`](@ref) and [`r2r!`](@ref), respectively.
 function plan_r2r end
 
 ## FFT: Implement fft by calling fftw.
+const version = Ref{Union{Missing,VersionNumber}}(missing)
 
-const version = VersionNumber(split(unsafe_string(cglobal(
-    (:fftw_version,libfftw3[]), UInt8)), ['-', ' '])[2])
-
+@static if FFTW.fftw_provider == "fftw"
+    version[] = VersionNumber(split(unsafe_string(cglobal(
+                              (:fftw_version,libfftw3[]), UInt8)), ['-', ' '])[2])
+end
 ## Direction of FFT
 
 const FORWARD = -1
@@ -422,7 +424,7 @@ end
 
 # The sprint_plan function was released in FFTW 3.3.4, but MKL versions
 # claiming to be FFTW 3.3.4 still don't seem to have this function.
-const has_sprint_plan = version >= v"3.3.4" && fftw_provider == "fftw"
+const has_sprint_plan = fftw_provider == "fftw" && version[] >= v"3.3.4"
 
 @static if has_sprint_plan
     sprint_plan_(plan::FFTWPlan{<:fftwDouble}) =

--- a/src/providers.jl
+++ b/src/providers.jl
@@ -79,11 +79,3 @@ end
         end
     end
 end
-
-# If we're using MKL, load it in and set library paths appropriately.
-@static if fftw_provider == "mkl"
-    import MKL_jll
-    libfftw3[] = MKL_jll.libmkl_rt_path
-    libfftw3f[] = MKL_jll.libmkl_rt_path
-    const _last_num_threads = Ref(Cint(1))
-end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -6,6 +6,7 @@
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+MKL_jll = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,10 @@ using FFTW: fftw_provider
 using AbstractFFTs: Plan, plan_inv
 using Test
 using LinearAlgebra
+# needs to be explicitly loaded for the extension to work on 1.9+
+@static if isdefined(Base, :get_extension)
+    import MKL_jll
+end
 
 using Aqua
 @testset "Project quality" begin


### PR DESCRIPTION
I've marked this as a breaking change because it requires explicitly loading MKL_jll (or MKL) to enable the support on 1.9+.