### PR TITLE
Do not fail if codecov fails

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macOS-13 # intel
-          - macOS-14 # arm
+          - macOS-latest # arm
         threads:
           - '1'
           - '2'
@@ -64,13 +64,13 @@ jobs:
           - os: macOS-13
             version: '1.6'
             provider: 'mkl'
-          - os: macOS-14
+          - os: macOS-latest
             arch: x86
-          - os: macOS-14
+          - os: macOS-latest
             arch: x64
-          - os: macOS-14
+          - os: macOS-latest
             version: '1.6'
-          - os: macOS-14
+          - os: macOS-latest
             provider: 'mkl'
             
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,7 +91,6 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:
-          fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }} # required
           file: lcov.info
 


### PR DESCRIPTION
We have the codecov token set up correctly, but this is still causing CI to fail. Don't gate PRs being green on codecov.