### PR TITLE
Backend token/struct API for AbstractFFTs

### DIFF
--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -4,7 +4,7 @@ using LinearAlgebra, Reexport, Preferences
 @reexport using AbstractFFTs
 using Base.Threads
 
-import AbstractFFTs: Plan, ScaledPlan,
+import AbstractFFTs: Plan, ScaledPlan, AbstractFFTBackend,
                      fft, ifft, bfft, fft!, ifft!, bfft!,
                      plan_fft, plan_ifft, plan_bfft, plan_fft!, plan_ifft!, plan_bfft!,
                      rfft, irfft, brfft, plan_rfft, plan_irfft, plan_brfft,
@@ -15,6 +15,11 @@ import AbstractFFTs: Plan, ScaledPlan,
 export dct, idct, dct!, idct!, plan_dct, plan_idct, plan_dct!, plan_idct!
 
 include("providers.jl")
+
+export FFTWBackend
+struct FFTWBackend <: AbstractFFTBackend end
+backend() = FFTWBackend()
+activate!() = AbstractFFTs.set_active_backend!(FFTW)
 
 function fftw_init_check()
     # If someone is trying to set the provider via the old environment variable, warn them that they
@@ -59,7 +64,9 @@ elseif fftw_provider == "mkl"
 end
 const libfftw3 = FakeLazyLibrary(:libfftw3_no_init, fftw_init_check, C_NULL)
 const libfftw3f = FakeLazyLibrary(:libfftw3f_no_init, fftw_init_check, C_NULL)
-
+function __init__()
+    activate!()
+end
 else
 @static if fftw_provider == "fftw"
     import FFTW_jll: libfftw3_path as libfftw3_no_init,
@@ -74,6 +81,7 @@ elseif fftw_provider == "mkl"
 end
 function __init__()
     fftw_init_check()
+    activate!()
 end
 end
 


### PR DESCRIPTION
This PR adds a backend token api as discussed in this [AbstractFFTs PR](https://github.com/JuliaMath/AbstractFFTs.jl/pull/146). It would be great if we could keep the main discussion on the general design in the AbstractFFT PR.

An additional FFTW specific consideration is the question if the AbstractFFTs PR is accepted, do we want to extend it to the `plan_x` functions which are not defined in AbstractFFTs, such as the r2r or the dct.

Also currently the `@infered` tests fail for the high-level interface, because the infered return type is a union of two plans. I haven't quite found a solution to that yet. In the setting that multiple FFT backends are loaded, this would be even "worse"/instable. 