### PR TITLE
Fix juliac `--trim`

### DIFF
--- a/src/FFTW.jl
+++ b/src/FFTW.jl
@@ -36,7 +36,7 @@ mutable struct FakeLazyLibrary{T}
     on_load_callback::T
     @atomic h::Ptr{Cvoid}
 end
-import Libdl: LazyLibrary, dlopen, dlsym
+import Libdl: LazyLibrary, dlopen
 function dlopen(lib::FakeLazyLibrary{T}) where T
     h = @atomic :monotonic lib.h
     h != C_NULL && return h

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -320,14 +320,26 @@ unsafe_convert(::Type{PlanPtr}, p::FFTWPlan) = p.plan
 # pushing the plan to be destroyed to the deferred_destroy_plans (which itself is protected by a lock).
 # This is accomplished by the maybe_destroy_plan function, which is used as the plan finalizer.
 
+struct FFTWPlanDestructor
+    ptr::PlanPtr
+    use_32bit_lib::Bool
+end
+
+FFTWPlanDestructor(plan::FFTWPlan{<:fftwSingle}) = FFTWPlanDestructor(plan.plan, true)
+FFTWPlanDestructor(plan::FFTWPlan{<:fftwDouble}) = FFTWPlanDestructor(plan.plan, false)
+
 # these functions should only be called while the fftwlock is held
-unsafe_destroy_plan(@nospecialize(plan::FFTWPlan{<:fftwDouble})) =
-    ccall((:fftw_destroy_plan,libfftw3), Cvoid, (PlanPtr,), plan)
-unsafe_destroy_plan(@nospecialize(plan::FFTWPlan{<:fftwSingle})) =
-    ccall((:fftwf_destroy_plan,libfftw3f), Cvoid, (PlanPtr,), plan)
+unsafe_destroy_plan(plan::FFTWPlan) = unsafe_destroy_plan(FFTWPlanDestructor(plan))
+function unsafe_destroy_plan(destructor::FFTWPlanDestructor)
+    if destructor.use_32bit_lib
+        ccall((:fftwf_destroy_plan,libfftw3f), Cvoid, (PlanPtr,), destructor.ptr)
+    else
+        ccall((:fftw_destroy_plan,libfftw3), Cvoid, (PlanPtr,), destructor.ptr)
+    end
+end
 
 const deferred_destroy_lock = ReentrantLock() # lock protecting the deferred_destroy_plans list
-const deferred_destroy_plans = FFTWPlan[]
+const deferred_destroy_plans = FFTWPlanDestructor[]
 
 function destroy_deferred()
     lock(deferred_destroy_lock)
@@ -375,7 +387,7 @@ function maybe_destroy_plan(plan::FFTWPlan)
                 unlock(fftwlock)
             end
         else
-            push!(deferred_destroy_plans, plan)
+            push!(deferred_destroy_plans, FFTWPlanDestructor(plan))
         end
     finally
         unlock(deferred_destroy_lock)
@@ -495,11 +507,11 @@ function assert_applicable(p::FFTWPlan{T,K,inplace}, X::StridedArray{T}, Y::Stri
     elseif alignment_of(Y) != p.oalign && p.flags & UNALIGNED == 0
         throw(ArgumentError("FFTW plan applied to output with wrong memory alignment"))
     elseif inplace != (pointer(X) == pointer(Y))
-        throw(ArgumentError(string("FFTW ",
+        throw(ArgumentError(join(["FFTW ",
                                    inplace ? "in-place" : "out-of-place",
                                    " plan applied to ",
                                    inplace ? "out-of-place" : "in-place",
-                                   " data")))
+                                   " data"])))
     end
 end
 

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -2,6 +2,7 @@
 
 import Base: show, *, convert, unsafe_convert, size, strides, ndims, pointer
 import LinearAlgebra: mul!
+import Libdl: dlopen, dlsym
 
 """
     r2r(A, kind [, dims])


### PR DESCRIPTION
This PR is the result a series of fixes I implemented for `FFTW` to play nicely with `juliac --trim`. Sort of solves https://github.com/JuliaMath/FFTW.jl/issues/319. Its not perfect, but I think it should be better than nothing for those of us who depend on `FFTW` for making meaningful evaluations of `--trim`. 

## Library Loading
This temporarily solves the issues surrounding the current way of loading libraries, which should be replaced in the future (as suggested by the comment at https://github.com/JuliaMath/FFTW.jl/blob/master/src/FFTW.jl#L33)
1. Add type parameter to `FakeLazyLibrary` for type stability. 

And two issues related to `ccall(::FakeLazyLibrary, ...)` forwarding the call to `dlopen(::FakeLazyLibrary`):

2. Call `dlopen` in `__init__`to ensure it gets precompiled (which won't happen by default since it is only called from the C layer).  
3. Manually running `Base.unsafe_store!(cglobal(:jl_libdl_dlopen_func, Any), dlopen)` before calling `fft` is necessary in all entrypoints for `ccall` to become aware of `dlopen`. Theoretically this could be done in `FFTW`, but I think its best to avoid messing with Julias internal mechanisms for applications outside of experimenting with `--trim`. 

The related code on the Julia side is https://github.com/JuliaLang/julia/blob/f5f4c0174ed51de3811da861c0bf01b4e9f10972/src/runtime_ccall.cpp#L86 and https://github.com/JuliaLang/julia/blob/41e50a77e6f6b9b2cfea9056529224c56923dac6/base/libdl.jl#L488. 

## Other Type-Instability Fixes
Some additional type instabilities that are probably worth fixing even if the library loading mechanism is updated in the future:

4. Add `FFTWPlanDestructor` for type stable destruction. 
5. Replace an occurence of `string(args...)` with `join([str1, str2, ...])`. 
6. Use a minimal type-stable equivalent of `@sync` in `spawnloop`. I would be happy for a better proposal for how to solve this. The core issue is that `spawnloop` is precompiled even if only one thread is used. The internal use of a `Channel{Any}` in `@sync` makes this problematic. Compared to https://github.com/JuliaLang/julia/blob/29a4bbf950aefa6116b296d48ef966ab36c5ca84/base/task.jl#L584, the only significant difference I can only see is that the real `@sync` gives a nicer handling and representation of errors. I hope I did not miss anything. Worst case, we could drop this from the PR and leave it to the user to override `spawnloop` using `--trim`.

## Example

With this PR the following will build with `--trim` and run without errors: 

```julia
using FFTW
using Libdl

function @main(ARGS)
    # Must be called before anything from FFTW
    Base.unsafe_store!(cglobal(:jl_libdl_dlopen_func, Any), dlopen)

    x = [1., 2., 3.]
    println(Core.stdout, "rfft([$(join(x, ", "))]) = [$(join(rfft(x), ", "))]")
    return 0
end
```