### PR TITLE
disallow `plan * real` for in-place complex plan

### DIFF
--- a/src/fft.jl
+++ b/src/fft.jl
@@ -833,10 +833,6 @@ for (f,direction) in ((:fft,FORWARD), (:bfft,BACKWARD))
     end
 end
 
-function mul!(y::AbstractArray, p::cFFTWPlan{T}, x::AbstractArray) where T
-    throw(ArgumentError("mul!(x,::cFFTWPlan{$(T)},y) expects x and y be of type StridedArray{$(T)}"))
-end
-
 function mul!(y::StridedArray{T}, p::cFFTWPlan{T}, x::StridedArray{T}) where T
     assert_applicable(p, x, y)
     unsafe_execute!(p, x, y)
@@ -1055,10 +1051,6 @@ function mul!(y::StridedArray{T}, p::r2rFFTWPlan{T}, x::StridedArray{T}) where T
     assert_applicable(p, x, y)
     unsafe_execute!(p, x, y)
     return y
-end
-
-function mul!(y::AbstractArray, p::r2rFFTWPlan{T}, x::AbstractArray) where T
-    throw(ArgumentError("mul!(x,::r2rFFTWPlan{$(T)},y) expects x and y be of type StridedArray{$(T)}"))
 end
 
 function *(p::r2rFFTWPlan{T,K,false}, x::StridedArray{T,N}) where {T,K,N}

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -829,6 +829,10 @@ for (f,direction) in ((:fft,FORWARD), (:bfft,BACKWARD))
     end
 end
 
+function mul!(y::AbstractArray, p::cFFTWPlan{T}, x::AbstractArray) where T
+    throw(ArgumentError("mul!(x,::cFFTWPlan{$(T)},y) expects x and y be of type StridedArray{$(T)}"))
+end
+
 function mul!(y::StridedArray{T}, p::cFFTWPlan{T}, x::StridedArray{T}) where T
     assert_applicable(p, x, y)
     unsafe_execute!(p, x, y)
@@ -1047,6 +1051,10 @@ function mul!(y::StridedArray{T}, p::r2rFFTWPlan{T}, x::StridedArray{T}) where T
     assert_applicable(p, x, y)
     unsafe_execute!(p, x, y)
     return y
+end
+
+function mul!(y::AbstractArray, p::r2rFFTWPlan{T}, x::AbstractArray) where T
+    throw(ArgumentError("mul!(x,::r2rFFTWPlan{$(T)},y) expects x and y be of type StridedArray{$(T)}"))
 end
 
 function *(p::r2rFFTWPlan{T,K,false}, x::StridedArray{T,N}) where {T,K,N}

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -832,7 +832,7 @@ function *(p::cFFTWPlan{T,K,false}, x::StridedArray{T,N}) where {T,K,N}
     return y
 end
 
-function *(p::cFFTWPlan{T,K,true}, x::StridedArray{T}) where {T,K}
+function *(p::cFFTWPlan{T,K,true}, x::AbstractArray) where {T,K}
     assert_applicable(p, x)
     unsafe_execute!(p, x, x)
     return x
@@ -1046,7 +1046,7 @@ function *(p::r2rFFTWPlan{T,K,false}, x::StridedArray{T,N}) where {T,K,N}
     return y
 end
 
-function *(p::r2rFFTWPlan{T,K,true}, x::StridedArray{T}) where {T,K}
+function *(p::r2rFFTWPlan{T,K,true}, x::AbstractArray) where {T,K}
     assert_applicable(p, x)
     unsafe_execute!(p, x, x)
     return x

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -504,12 +504,16 @@ function assert_applicable(p::FFTWPlan{T,K,inplace}, X::StridedArray{T}, Y::Stri
 end
 
 
-function assert_applicable(p::FFTWPlan{T}, X::AbstractArray) where T
-    throw(ArgumentError("In-place plan  FFTWPlan{$(T)} cannot be applied to a $(typeof(X))"))
+function assert_applicable(p::FFTWPlan{T,K, inplace}, X::AbstractArray) where {T,K, inplace}
+    if inplace
+        throw(ArgumentError("In-place plan  FFTWPlan{$(T)} cannot be applied to a $(typeof(X))"))
+    end
 end
 
-function assert_applicable(p::FFTWPlan{T}, X::AbstractArray, Y::AbstractArray) where T
-    throw(ArgumentError("In-place plan  FFTWPlan{$(T)} cannot be applied to a $(typeof(X))"))
+function assert_applicable(p::FFTWPlan{T, K, inplace}, X::AbstractArray, Y::AbstractArray) where {T,K, inplace}
+    if inplace
+        throw(ArgumentError("In-place plan  FFTWPlan{$(T)} cannot be applied to a $(typeof(X))"))
+    end
 end
 
 

--- a/src/fft.jl
+++ b/src/fft.jl
@@ -503,6 +503,16 @@ function assert_applicable(p::FFTWPlan{T,K,inplace}, X::StridedArray{T}, Y::Stri
     end
 end
 
+
+function assert_applicable(p::FFTWPlan{T}, X::AbstractArray) where T
+    throw(ArgumentError("In-place plan  FFTWPlan{$(T)} cannot be applied to a $(typeof(X))"))
+end
+
+function assert_applicable(p::FFTWPlan{T}, X::AbstractArray, Y::AbstractArray) where T
+    throw(ArgumentError("In-place plan  FFTWPlan{$(T)} cannot be applied to a $(typeof(X))"))
+end
+
+
 # strides for a column-major (Julia-style) array of size == sz
 colmajorstrides(::Tuple{}) = ()
 colmajorstrides(sz) = _colmajorstrides(1, sz...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -592,12 +592,12 @@ end
     complexplan = plan_fft!(zeros(ComplexF64, 4))
     realvec = [1,1,1,1]
 
-    @test_throws ArgumentError FFTW.mul!(realvec, complexplan, realvec)
+    @test_throws MethodError FFTW.mul!(realvec, complexplan, realvec)
     @test_throws ArgumentError complexplan * realvec
 
     complexvec=ones(ComplexF64,4)
     realplan = FFTW.plan_r2r!(zeros(4), FFTW.REDFT10)
-    @test_throws ArgumentError FFTW.mul!(complexvec, realplan, complexvec)
+    @test_throws MethodError FFTW.mul!(complexvec, realplan, complexvec)
     @test_throws ArgumentError realplan * complexvec 
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -592,42 +592,12 @@ end
     complexplan = plan_fft!(zeros(ComplexF64, 4))
     realvec = [1,1,1,1]
 
-    catched_typerror=false
-    try
-        FFTW.mul!(realvec, complexplan, realvec)
-    catch e;
-        println(e,"\n")
-        catched_typerror = true
-    end
-    @test catched_typerror
-    
-    catched_typerror=false
-    try
-        complexplan * realvec 
-    catch e;
-        println(e,"\n")
-        catched_typerror = true
-    end
-    @test catched_typerror
+    @test_throws MethodError FFTW.mul!(realvec, complexplan, realvec)
+    @test_throws MethodError complexplan * realvec
 
     complexvec=ones(ComplexF64,4)
     realplan = FFTW.plan_r2r!(zeros(4), FFTW.REDFT10)
-    catched_typerror=false
-    try
-        FFTW.mul!(complexvec, realplan, complexvec)
-    catch e;
-        println(e,"\n")
-        catched_typerror = true
-    end
-    @test catched_typerror
-    
-    catched_typerror=false
-    try
-        realplan * complexvec 
-    catch e;
-        println(e,"\n")
-        catched_typerror = true
-    end
-    @test catched_typerror
+    @test_throws MethodError FFTW.mul!(complexvec, realplan, complexvec)
+    @test_throws MethodError realplan * complexvec 
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -593,11 +593,11 @@ end
     realvec = [1,1,1,1]
 
     @test_throws MethodError FFTW.mul!(realvec, complexplan, realvec)
-    @test_throws MethodError complexplan * realvec
+    @test_throws ArgumentError complexplan * realvec
 
     complexvec=ones(ComplexF64,4)
     realplan = FFTW.plan_r2r!(zeros(4), FFTW.REDFT10)
     @test_throws MethodError FFTW.mul!(complexvec, realplan, complexvec)
-    @test_throws MethodError realplan * complexvec 
+    @test_throws ArgumentError realplan * complexvec 
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -588,7 +588,7 @@ end
 end
 
 
-@testset "Ensure inline version throws with wrong type" begin
+@testset "Ensure in-place version throws with wrong type" begin
     complexplan = plan_fft!(zeros(ComplexF64, 4))
     realvec = [1,1,1,1]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -586,3 +586,28 @@ end
         AbstractFFTs.TestUtils.test_real_ffts(Array; copy_input=true)
     end
 end
+
+
+@testset "Avoid copy with inline version" begin
+    complexplan = plan_fft!(zeros(ComplexF64, 4))
+    realvec = [1,1,1,1]
+
+    catched_typerror=false
+    try
+        FFTW.mul!(realvec, complexplan, realvec)
+    catch e;
+        println(e,"\n")
+        catched_typerror = true
+    end
+    @test catched_typerror
+    
+    catched_typerror=false
+    try
+        complexplan * realvec 
+    catch e;
+        println(e,"\n")
+        catched_typerror = true
+    end
+    @test catched_typerror
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -588,7 +588,7 @@ end
 end
 
 
-@testset "Avoid copy with inline version" begin
+@testset "Ensure inline version throws with wrong type" begin
     complexplan = plan_fft!(zeros(ComplexF64, 4))
     realvec = [1,1,1,1]
 
@@ -604,6 +604,26 @@ end
     catched_typerror=false
     try
         complexplan * realvec 
+    catch e;
+        println(e,"\n")
+        catched_typerror = true
+    end
+    @test catched_typerror
+
+    complexvec=ones(ComplexF64,4)
+    realplan = FFTW.plan_r2r!(zeros(4), FFTW.REDFT10)
+    catched_typerror=false
+    try
+        FFTW.mul!(complexvec, realplan, complexvec)
+    catch e;
+        println(e,"\n")
+        catched_typerror = true
+    end
+    @test catched_typerror
+    
+    catched_typerror=false
+    try
+        realplan * complexvec 
     catch e;
         println(e,"\n")
         catched_typerror = true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -592,12 +592,12 @@ end
     complexplan = plan_fft!(zeros(ComplexF64, 4))
     realvec = [1,1,1,1]
 
-    @test_throws MethodError FFTW.mul!(realvec, complexplan, realvec)
+    @test_throws ArgumentError FFTW.mul!(realvec, complexplan, realvec)
     @test_throws ArgumentError complexplan * realvec
 
     complexvec=ones(ComplexF64,4)
     realplan = FFTW.plan_r2r!(zeros(4), FFTW.REDFT10)
-    @test_throws MethodError FFTW.mul!(complexvec, realplan, complexvec)
+    @test_throws ArgumentError FFTW.mul!(complexvec, realplan, complexvec)
     @test_throws ArgumentError realplan * complexvec 
 
 end


### PR DESCRIPTION
When applying a complex in-place plan to a real vector, '*' should throw similar to 'mul!'.
However, AbstractFFTs.jl defines  [`*(::Plan{T}, ::AbstractArray)`](https://github.com/JuliaMath/AbstractFFTs.jl/blob/31fc5f4de1d5a4f0f1565e879ff519d46255b02a/src/definitions.jl#L224) which copies the real vector to a `Vector{T}`  which then is passed to the  [`*(cFFTWPlan{T,K,true}, StridedArray{T})`](https://github.com/JuliaMath/FFTW.jl/blob/290d1611f3325249c0893c69f0a844182fa825b5/src/fft.jl#L835) method in FFTW.jl which now calculates and return the complex FFT for the complex vector without ever knowing that it should mutate the vector it has been passed.

Issue #341 has an MWE which shows what happens.

This PR changes the signature of `*(cFFTWPlan{T,K,true}, StridedArray{T})` to                  `*(cFFTWPlan{T,K,true}, AbstractArray)`. Now this method is directly invoked and throws as expected.  A test for this behavior has been added.

Fixes #341.


